### PR TITLE
[Fix] Resolve CPU debug interface and AXI memory timing bugs

### DIFF
--- a/rtl/interfaces/axi4lite_master.sv
+++ b/rtl/interfaces/axi4lite_master.sv
@@ -184,7 +184,8 @@ module axi4lite_master
     assign m_axi_rready = (state_q == AXI_R_WAIT);
 
     // Memory interface outputs
-    assign mem_rdata = rdata_q;
+    // Bypass rdata_q register when read is completing to avoid 1-cycle delay
+    assign mem_rdata = (state_q == AXI_R_WAIT && m_axi_rvalid) ? m_axi_rdata : rdata_q;
     assign mem_ready = (state_q == AXI_IDLE);
     assign mem_valid = (state_q == AXI_R_WAIT && m_axi_rvalid) ||
                        (state_q == AXI_B_WAIT && m_axi_bvalid);


### PR DESCRIPTION
  ## Summary
  - Fix AXI master memory read timing bug causing instruction fetch failures
  - Fix debug halt request being ignored in non-FETCH CPU states
  - Fix single-step mode not halting after one instruction

  ## Test plan
  - [x] Run `make sim` in WSL Ubuntu
  - [x] Verify all 19 testbench tests pass
  - [x] ALU Program Test: PASS
  - [x] Load/Store Test: PASS
  - [x] Branch Test: PASS
  - [x] Debug Halt/Resume Test: PASS
  - [x] Debug Register Access Test: PASS
  - [x] Breakpoint Test: PASS
  - [x] Single-Step Test: PASS

  ## Changes

  ### 1. AXI Master Memory Read Timing (`rtl/interfaces/axi4lite_master.sv`)
  **Problem:** `mem_rdata` used the registered `rdata_q` value, causing a 1-cycle delay.

  **Fix:** Bypass the register when read transaction is completing.

  ### 2. Debug Halt Request (`rtl/core/rv32i_control.sv`)
  **Problem:** Halt request pulse was only checked in `CPU_FETCH` state.

  **Fix:** Added `dbg_halt_req` checks to all execution states.

  ### 3. Single-Step Tracking (`rtl/core/rv32i_control.sv`)
  **Problem:** `dbg_step_req` was a 1-cycle pulse that expired before the instruction completed.

  **Fix:** Added `stepping_q` register that persists from step initiation until instruction completes.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-step debugging with persistent stepping state across complete instruction execution cycles.
  * Enhanced halt request handling to function reliably at any CPU execution stage, including during memory operations.

* **Performance**
  * Reduced memory read data latency through optimized AXI bus transaction timing and improved data bypass paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->