### PR TITLE
[RTL] Fix verilator warnings

### DIFF
--- a/rtl/cpu/core/rv32i_decode.sv
+++ b/rtl/cpu/core/rv32i_decode.sv
@@ -223,7 +223,7 @@ module rv32i_decode (
         reg_wr_en = 1'b1;
         mem_rd    = 1'b1;
         alu_op    = ALU_ADD;
-        alu_src_a = 1'b0;  // rs1
+        alu_src_a = 2'b0;  // rs1
         alu_src_b = 1'b1;  // Immediate
 
         case (funct3)
@@ -261,7 +261,7 @@ module rv32i_decode (
         imm_fmt   = FMT_S;
         mem_wr    = 1'b1;
         alu_op    = ALU_ADD;
-        alu_src_a = 1'b0;  // rs1
+        alu_src_a = 2'b0;  // rs1
         alu_src_b = 1'b1;  // Immediate
 
         case (funct3)
@@ -287,7 +287,7 @@ module rv32i_decode (
       OP_IMM: begin
         imm_fmt   = FMT_I;
         reg_wr_en = 1'b1;
-        alu_src_a = 1'b0;  // rs1
+        alu_src_a = 2'b0;  // rs1
         alu_src_b = 1'b1;  // Immediate
 
         case (funct3)
@@ -340,7 +340,7 @@ module rv32i_decode (
       OP_REG: begin
         imm_fmt   = FMT_R;
         reg_wr_en = 1'b1;
-        alu_src_a = 1'b0;  // rs1
+        alu_src_a = 2'b0;  // rs1
         alu_src_b = 1'b0;  // rs2
 
         case (funct3)


### PR DESCRIPTION
Fix bit-width mismatch in alu_src_a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code consistency in core decoding logic through literal width alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->