### PR TITLE
[Doc] Update CLAUDE.md with approved heterogeneous SoC roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ See `docs/ROADMAP.md` for complete phase plan and `docs/PHASE_STATUS.md` for cur
 - **Divergence**: Single-level SIMT stack with per-lane active mask
 - **Scheduler**: Round-robin warp selection
 - **Shared memory**: 16 KB scratchpad, 32 banks
-- **Memory**: AXI4-Lite master + memory coalescer (8-lane requests → fewer AXI transactions)
+- **Memory**: AXI4 master (burst-capable) + memory coalescer (8-lane requests → fewer AXI4 burst transactions)
 - **Control interface**: AXI-Lite slave (kernel launch via command queue)
 - **CPU notification**: Interrupt output on kernel completion
 - **Coherency**: Software-managed — CPU flushes D-cache before kernel launch; CPU invalidates D-cache after kernel completion. No hardware coherence protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,37 @@ See `docs/ROADMAP.md` for complete phase plan and `docs/PHASE_STATUS.md` for cur
 
 - **Phase 3**: Memory system with I-cache + D-cache (write-back, no coherence) ← CURRENT
 - **Phase 4**: GPU-lite SIMT compute engine (8-lane warps, single compute unit, no graphics)
-- **Phase 5**: SoC integration (CPU + GPU + DMA + UART + SPI + Timer + Boot ROM)
+- **Phase 5**: SoC integration (CPU + GPU + DMA + AXI4 crossbar + UART + SPI + Timer + behavioral SRAM)
 
 **Note**: GPU in Phase 4 requires Phase 2+ CPU for interrupt support (kernel completion notifications)
+
+### Phase 4: GPU-Lite SIMT Engine (Planned)
+
+- **ISA**: Custom 32-bit vector encoding — VADD, VSUB, VMUL, VAND, VOR, VSLL, VLD, VST, VBEQ, VBNE, VJMP, VRET, VSYNC
+- **Execution**: Single compute unit; 8 SIMD lanes; 8 warps max; 64 total threads
+- **Register file**: 32 registers × 8 threads per warp (1 KB total)
+- **Divergence**: Single-level SIMT stack with per-lane active mask
+- **Scheduler**: Round-robin warp selection
+- **Shared memory**: 16 KB scratchpad, 32 banks
+- **Memory**: AXI4-Lite master + memory coalescer (8-lane requests → fewer AXI transactions)
+- **Control interface**: AXI-Lite slave (kernel launch via command queue)
+- **CPU notification**: Interrupt output on kernel completion
+- **Coherency**: Software-managed — CPU flushes D-cache before kernel launch; CPU invalidates D-cache after kernel completion. No hardware coherence protocol.
+- **Spec**: `docs/design/PHASE4_GPU_ARCHITECTURE_SPEC.md`
+
+### Phase 5: SoC Integration (Planned)
+
+- **Interconnect**: AXI4 crossbar (data fabric) + AXI-Lite bus (control/config)
+  - AXI4 masters: CPU D-cache (upgraded to burst mode), GPU, DMA engine
+  - AXI4 slave: behavioral SRAM controller (no DRAM refresh)
+  - AXI-Lite slaves: GPU config registers, DMA control registers, UART, SPI, timer, IRQ controller
+- **Cache upgrade**: Phase 3 refill FSMs upgraded from 4 sequential AXI4-Lite beats to AXI4 burst transactions
+- **DMA engine**: Descriptor queue, AXI4 master, interrupt output to CPU
+- **Peripherals**: UART, SPI, timer, interrupt controller (routed to CPU M-mode external interrupt)
+- **Memory model**: Behavioral AXI4-slave SRAM (no DRAM refresh logic)
+- **Power domains**: PD_CPU, PD_GPU, PD_SRAM, PD_PERIPH (clock gating + power gating per `UPF_POWER_SPEC.md`)
+- **Performance counters**: CSR-mapped — cycle count, instructions retired, branch mispredictions, I$/D$ miss counts, active warps, warp stall cycles, divergence events
+- **Benchmarks**: CPU (vector add, dot product, memcpy, branch loop); GPU (vector add, parallel reduction, matrix multiply, prefix scan, divergence test)
 
 ## Key Documentation
 
@@ -273,6 +301,14 @@ Complete register map in `docs/design/MEMORY_MAP.md`.
 - No cache coherence with CPU
 - Memory coalescing when possible
 
+**Phase 5 SoC — Locked Architecture Decisions** (confirmed 2026-03-28):
+
+1. **Cache line size**: 16 bytes locked for Phase 3. Revisit 32-byte lines only if/when an L2 cache is added.
+2. **Cache associativity**: Direct-mapped locked for Phase 3. Upgrade to 2-way I-cache / 1-4 way D-cache only if Phase 5 benchmarks prove measurable conflict-miss impact.
+3. **AXI4 burst upgrade**: Phase 3 refill FSMs use 4 sequential AXI4-Lite transactions. These are upgraded to AXI4 burst mode during Phase 5 SoC integration — do not change Phase 3 FSMs before then.
+4. **L2 cache**: Not in base Phase 5 scope. Add only if Phase 5 benchmarking shows L1 miss rates are a bottleneck.
+5. **DRAM controller**: Use behavioral AXI4-slave SRAM model for Phase 5. Real DRAM controller (with refresh) is a Phase 6+ stretch goal only if tape-out is targeted.
+
 ## Reference Model (Python)
 
 **Phase 0 deliverable**: Python reference models for CPU and GPU
@@ -356,6 +392,29 @@ See `docs/verification/VERIFICATION_PLAN.md` for phase-by-phase verification pla
 7. ⏸️ **Backend flow**: Synthesis + P&R + STA at 75 MHz (Sky130, SRAM macros)
 8. ⏸️ **Sign-off**: Coverage analysis, final review
 
+### Phase 4 Workflow (Planned — GPU-Lite)
+
+1. ⏸️ **Architecture review**: Confirm `docs/design/PHASE4_GPU_ARCHITECTURE_SPEC.md` covers all open questions
+2. ⏸️ **Write GPU RTL**: 9 modules in `rtl/gpu/` (see Project Structure above)
+3. ⏸️ **Unit tests**: Warp scheduling, SIMT divergence, memory coalescing, shared memory
+4. ⏸️ **GPU kernel tests**: Vector add, parallel reduction, divergence test kernels
+5. ⏸️ **Phase 3 regression**: All cache + Phase 2 tests must still pass
+6. ⏸️ **Backend flow**: Synthesis + P&R + STA for GPU block
+7. ⏸️ **Sign-off**: GPU verified standalone; ready for SoC integration
+
+### Phase 5 Workflow (Planned — SoC Integration)
+
+1. ⏸️ **AXI4 interconnect**: Build `axi4_crossbar.sv`, `axi_lite_interconnect.sv`; upgrade Phase 3 cache refill FSMs to AXI4 burst mode
+2. ⏸️ **Peripherals**: UART, SPI, timer, interrupt controller, DMA engine in `rtl/periph/`
+3. ⏸️ **SRAM controller**: Behavioral AXI4-slave in `rtl/soc/sram_controller.sv`
+4. ⏸️ **SoC top integration**: Wire CPU + GPU + DMA + peripherals in `rtl/soc/soc_top.sv`
+5. ⏸️ **Performance counters**: Add CSR-mapped counters (cache misses, branch mispredictions, warp stalls, divergence events)
+6. ⏸️ **CPU-GPU integration tests**: Kernel launch → interrupt → result read; DMA transfers; software coherency sequence
+7. ⏸️ **Full regression**: All prior tests; CPU + GPU benchmarks
+8. ⏸️ **L2 cache evaluation**: Review L1 miss rates from benchmarks; add `rtl/mem/l2_cache.sv` only if justified
+9. ⏸️ **Backend flow**: Full SoC synthesis + P&R + STA; `pnr/constraints/phase5_soc.sdc`, `phase5_soc.upf`
+10. ⏸️ **Sign-off**: Coverage, power analysis, final review
+
 ## Project Structure
 
 ```text
@@ -395,9 +454,28 @@ See `docs/verification/VERIFICATION_PLAN.md` for phase-by-phase verification pla
 │   │   ├── rv32i_icache.sv            # I-cache (4 KB, direct-mapped)
 │   │   ├── rv32i_dcache.sv            # D-cache (4 KB, write-back)
 │   │   └── rv32i_cache_arbiter.sv     # D$ priority AXI arbiter
-│   ├── gpu/
-│   ├── periph/
-│   └── soc/
+│   ├── gpu/                           # NEW in Phase 4: GPU-Lite RTL
+│   │   ├── gpu_top.sv                 # GPU top (AXI4-Lite ctrl + AXI4 mem + IRQ)
+│   │   ├── gpu_command_queue.sv       # Kernel descriptor queue (PC, grid, block, args)
+│   │   ├── warp_scheduler.sv          # Round-robin scheduler (warp_id, PC, active_mask, ready)
+│   │   ├── gpu_compute_unit.sv        # Vector ALU + register file + SIMT divergence stack
+│   │   ├── vector_register_file.sv    # 32 regs × 8 threads per warp
+│   │   ├── vector_alu.sv              # VADD/VSUB/VMUL/VAND/VOR/VSLL per lane
+│   │   ├── gpu_memory_unit.sv         # Global load/store with AXI burst generation
+│   │   ├── memory_coalescer.sv        # 8-lane requests → fewer AXI bursts
+│   │   └── shared_memory.sv           # 16 KB scratchpad, 32 banks
+│   ├── periph/                        # NEW in Phase 5: peripheral RTL
+│   │   ├── uart_controller.sv
+│   │   ├── spi_controller.sv
+│   │   ├── timer.sv
+│   │   ├── interrupt_controller.sv
+│   │   └── dma_engine.sv              # Descriptor queue + AXI4 master + IRQ
+│   └── soc/                           # NEW in Phase 5: SoC integration RTL
+│       ├── soc_top.sv                 # Top-level: CPU + GPU + DMA + peripherals
+│       ├── axi4_crossbar.sv           # N-master M-slave AXI4 data fabric
+│       ├── axi_lite_interconnect.sv   # AXI-Lite control bus
+│       ├── axi_lite_register_bank.sv  # GPU/DMA config registers
+│       └── sram_controller.sv         # Behavioral AXI4-slave SRAM (no DRAM refresh)
 ├── tb/                       # Testbench
 │   ├── models/               # Python reference models
 │   │   ├── rv32i_model.py
@@ -509,6 +587,55 @@ See `docs/PHASE_STATUS.md` for current status and immediate next steps.
 4. **Physical Design** (follows verification)
    - ⏸️ Synthesis + P&R + STA at 75 MHz on Sky130
    - ⏸️ `pnr/constraints/phase3_cache.sdc` and `phase3_cache.upf`
+
+**Phase 4 Tasks** (follows Phase 3 sign-off):
+
+1. **RTL Implementation**
+   - ⏸️ `rtl/gpu/gpu_top.sv` — top-level with AXI4-Lite control + AXI4 memory + IRQ
+   - ⏸️ `rtl/gpu/gpu_command_queue.sv` — kernel descriptor: PC, grid size, block size, arg pointer
+   - ⏸️ `rtl/gpu/warp_scheduler.sv` — round-robin; warp state: warp_id, PC, active_mask, ready
+   - ⏸️ `rtl/gpu/gpu_compute_unit.sv` — vector ALU + register file + SIMT divergence stack
+   - ⏸️ `rtl/gpu/vector_register_file.sv` — 32 regs × 8 threads per warp
+   - ⏸️ `rtl/gpu/vector_alu.sv` — VADD, VSUB, VMUL, VAND, VOR, VSLL per lane
+   - ⏸️ `rtl/gpu/gpu_memory_unit.sv` — global load/store with AXI burst generation
+   - ⏸️ `rtl/gpu/memory_coalescer.sv` — coalesces 8-lane requests into fewer AXI bursts
+   - ⏸️ `rtl/gpu/shared_memory.sv` — 16 KB scratchpad, 32 banks
+
+2. **Verification**
+   - ⏸️ Unit tests: `tb/cocotb/gpu/test_warp_scheduler.py`, `test_compute_unit.py`, `test_memory_unit.py`
+   - ⏸️ Kernel tests: vector add, parallel reduction, divergence test
+   - ⏸️ Phase 3 full regression (111+ tests must still pass)
+
+3. **Physical Design**
+   - ⏸️ GPU block synthesis + P&R + STA
+   - ⏸️ `pnr/constraints/phase4_gpu.sdc`, `phase4_gpu.upf`
+
+**Phase 5 Tasks** (follows Phase 4 sign-off):
+
+1. **AXI4 Interconnect** (build first — prerequisite for integration)
+   - ⏸️ `rtl/soc/axi4_crossbar.sv` — N-master M-slave data fabric
+   - ⏸️ `rtl/soc/axi_lite_interconnect.sv` — control bus
+   - ⏸️ `rtl/soc/axi_lite_register_bank.sv` — GPU + DMA config registers
+   - ⏸️ Upgrade Phase 3 refill FSMs to AXI4 burst mode
+
+2. **Peripherals + DMA**
+   - ⏸️ `rtl/periph/dma_engine.sv`, `uart_controller.sv`, `spi_controller.sv`, `timer.sv`, `interrupt_controller.sv`
+
+3. **SoC Integration**
+   - ⏸️ `rtl/soc/sram_controller.sv` — behavioral AXI4-slave SRAM
+   - ⏸️ `rtl/soc/soc_top.sv` — full SoC top-level
+   - ⏸️ Performance counters added as CSR-mapped registers
+
+4. **Verification**
+   - ⏸️ CPU-GPU integration: kernel launch → interrupt → result read
+   - ⏸️ Software coherency: CPU D-cache flush → GPU kernel → CPU D-cache invalidate
+   - ⏸️ DMA transfer tests; full benchmark suite (CPU + GPU kernels)
+   - ⏸️ L2 cache decision: add `rtl/mem/l2_cache.sv` only if L1 miss rates justify it
+
+5. **Physical Design**
+   - ⏸️ Full SoC synthesis + P&R + STA
+   - ⏸️ `pnr/constraints/phase5_soc.sdc`, `phase5_soc.upf`
+   - ⏸️ Power domain validation (PD_CPU, PD_GPU, PD_SRAM, PD_PERIPH)
 
 ## Questions?
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,13 @@ See `docs/ROADMAP.md` for complete phase plan and `docs/PHASE_STATUS.md` for cur
 
 ### Phase 6+: IP Expansion and Tech Node Exploration (Future)
 
-**Additional peripheral IPs** — all attach as AXI4-Lite slaves on the Phase 5 peripheral ring:
+**Additional peripheral IPs** — GPIO through TRNG attach as pure AXI4-Lite slaves on the Phase 5 peripheral ring; the AES/SHA-256 accelerator splits control and data planes:
 - **GPIO controller** — general I/O pad ring; needed by virtually every embedded SoC
 - **I2C controller** — sensor/EEPROM interface; complements Phase 5 SPI
 - **PWM controller** — counter + compare registers; motor/LED control
 - **Watchdog timer** — counter with AON-domain reset output; embedded safety
 - **TRNG** — ring-oscillator entropy source; Sky130 analog oscillators usable
-- **AES/SHA-256 accelerator** — AXI4 slave; AES-128 round function fits ~6 LUT levels at 75 MHz on Sky130
+- **AES/SHA-256 accelerator** — AXI4-Lite slave for control/status and key/IV/digest registers; AXI4 master+slave for bulk plaintext/ciphertext DMA; AES-128 round function fits ~6 LUT levels at 75 MHz on Sky130
 
 **NPU (Neural Processing Unit)** — attach as AXI4 master+slave on the Phase 5 crossbar:
 - Minimal viable config: 4×4 INT8 MAC array (16 MACs, 64 ops/cycle), 16 KB weight SRAM
@@ -692,7 +692,7 @@ See `docs/PHASE_STATUS.md` for current status and immediate next steps.
    - ⏸️ `rtl/periph/pwm_controller.sv` — configurable counter + compare, N channels
    - ⏸️ `rtl/periph/watchdog_timer.sv` — AON-domain counter, system reset output
    - ⏸️ `rtl/periph/trng.sv` — ring-oscillator entropy source (Sky130 analog cells)
-   - ⏸️ `rtl/periph/aes_sha_accel.sv` — AXI4 slave; AES-128 + SHA-256 pipeline
+   - ⏸️ `rtl/periph/aes_sha_accel.sv` — AXI4-Lite slave (control/status, key/IV/digest registers) + AXI4 master/slave (bulk data DMA); AES-128 + SHA-256 pipeline
 
 2. **NPU (Minimal INT8 Inference Engine)**
    - ⏸️ `rtl/npu/npu_top.sv` — AXI4 master (activations) + AXI4-Lite slave (config) + IRQ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,24 @@ See `docs/ROADMAP.md` for complete phase plan and `docs/PHASE_STATUS.md` for cur
 
 **Note**: GPU in Phase 4 requires Phase 2+ CPU for interrupt support (kernel completion notifications)
 
+### Phase 6+: IP Expansion and Tech Node Exploration (Future)
+
+**Additional peripheral IPs** — all attach as AXI4-Lite slaves on the Phase 5 peripheral ring:
+- **GPIO controller** — general I/O pad ring; needed by virtually every embedded SoC
+- **I2C controller** — sensor/EEPROM interface; complements Phase 5 SPI
+- **PWM controller** — counter + compare registers; motor/LED control
+- **Watchdog timer** — counter with AON-domain reset output; embedded safety
+- **TRNG** — ring-oscillator entropy source; Sky130 analog oscillators usable
+- **AES/SHA-256 accelerator** — AXI4 slave; AES-128 round function fits ~6 LUT levels at 75 MHz on Sky130
+
+**NPU (Neural Processing Unit)** — attach as AXI4 master+slave on the Phase 5 crossbar:
+- Minimal viable config: 4×4 INT8 MAC array (16 MACs, 64 ops/cycle), 16 KB weight SRAM
+- Sufficient for keyword spotting / gesture detection class workloads (~3.2 GOPS at 50 MHz)
+- Sky130 estimate: ~5,000 cells, ~20–30 µm², ~5–10 mW; Phase 6 IP
+- Full NPU (INT4, tiling, sparsity) benefits from FreePDK45 or ASAP7 node
+
+**Tech node progression**: Sky130 → FreePDK45/NanGate45 → ASAP7 (see Technology Node Strategy below)
+
 ### Phase 4: GPU-Lite SIMT Engine (Planned)
 
 - **ISA**: Custom 32-bit vector encoding — VADD, VSUB, VMUL, VAND, VOR, VSLL, VLD, VST, VBEQ, VBNE, VJMP, VRET, VSYNC
@@ -116,6 +134,33 @@ See `docs/ROADMAP.md` for complete phase plan and `docs/PHASE_STATUS.md` for cur
 | `pnr/README.md` | Physical design directory structure |
 | `pnr/constraints/phase1_cpu.sdc` | Phase 1 timing constraints |
 | `pnr/constraints/phase1_cpu.upf` | Phase 1 power intent |
+
+## Technology Node Strategy
+
+Three nodes are supported by the existing `pnr/Makefile`. Use the right node for the right goal:
+
+| Node | Makefile target | Config status | Realistic CPU freq | Fabricatable | Best use |
+|------|----------------|---------------|-------------------|--------------|----------|
+| **Sky130 130nm** | `librelane-sky130`, `docker-run` | ✅ Complete | 75–100 MHz | ✅ Yes (SkyWater MPW) | Functional sign-off; tape-out candidate |
+| **FreePDK45 / NanGate45 45nm** | `librelane-nangate45` | ✅ Complete (`pnr/freepdk45/`) | 150–250 MHz | No (predictive) | First non-Sky130 exploration; SRAM macros available |
+| **ASAP7 7nm FinFET** | `librelane-asap7` | ❌ Missing (`pnr/asap7/` absent) | 400–600 MHz | No (predictive) | Long-range performance projection only |
+
+### Sky130 PPA ceiling (assessed 2026-03-28)
+Sky130 130nm is frequency-limited by cell drive strength and clock tree skew. The realistic ceiling for this pipeline topology is **~100–120 MHz** with all optimisations applied — not the 200–500 MHz originally targeted.
+
+| Technique | Gain | Effort |
+|-----------|------|--------|
+| Switch to `sky130_fd_sc_hs` (high-speed cell library) | +10–30 MHz | Low — Makefile config change |
+| EX-stage retiming (split ALU + branch-compare) | +15–25 MHz | Medium — re-verify forwarding paths |
+| SDC multi-cycle exemptions for CSR/debug paths | +5–10 MHz | Low — SDC annotation only |
+| Floorplan: place forwarding mux adjacent to ALU | +5–10 MHz | Medium — P&R iteration |
+| **Combined ceiling** | **~100–120 MHz** | |
+
+### FreePDK45/NanGate45 (ready to run)
+`pnr/freepdk45/` is fully configured: `config.json` (2.5 ns / 400 MHz target), SRAM macros (`sram_1rw_256x32_freepdk45` with LEF/LIB/GDS), `macro_placement.cfg`, `pdn.tcl`, `freepdk45.sdc`, `freepdk45.upf`. Run with `make librelane-nangate45`. Expected Phase 2 result: 150–250 MHz, ~8–10× logic density vs Sky130.
+
+### ASAP7 (config needs creating)
+`pnr/Makefile` wires up `librelane-asap7` but `pnr/asap7/` does not exist. To enable: create `pnr/asap7/config.json` (model after `pnr/freepdk45/config.json`), a new SDC at 2.0–2.5 ns, and either a synthesised FF-array SRAM or OpenRAM ASAP7 macros (experimental). Run Phase 2 CPU first (no SRAM complications). Expected: 400–600 MHz, ~100× logic density vs Sky130.
 
 ### Verification
 
@@ -300,6 +345,8 @@ Complete register map in `docs/design/MEMORY_MAP.md`.
 - One-level divergence handling
 - No cache coherence with CPU
 - Memory coalescing when possible
+
+**Sky130 frequency ceiling**: ~100–120 MHz maximum for this CPU pipeline topology (see Technology Node Strategy). PDK limitation — not an RTL issue. For higher frequencies, target FreePDK45/NanGate45 (150–250 MHz) or ASAP7 (400–600 MHz).
 
 **Phase 5 SoC — Locked Architecture Decisions** (confirmed 2026-03-28):
 
@@ -636,6 +683,27 @@ See `docs/PHASE_STATUS.md` for current status and immediate next steps.
    - ⏸️ Full SoC synthesis + P&R + STA
    - ⏸️ `pnr/constraints/phase5_soc.sdc`, `phase5_soc.upf`
    - ⏸️ Power domain validation (PD_CPU, PD_GPU, PD_SRAM, PD_PERIPH)
+
+**Phase 6+ Tasks** (follows Phase 5 sign-off):
+
+1. **Additional Peripherals** (AXI4-Lite slaves on existing Phase 5 interconnect)
+   - ⏸️ `rtl/periph/gpio_controller.sv` — pad ring, direction control, interrupt on edge
+   - ⏸️ `rtl/periph/i2c_controller.sv` — multi-master I2C, SCL/SDA open-drain
+   - ⏸️ `rtl/periph/pwm_controller.sv` — configurable counter + compare, N channels
+   - ⏸️ `rtl/periph/watchdog_timer.sv` — AON-domain counter, system reset output
+   - ⏸️ `rtl/periph/trng.sv` — ring-oscillator entropy source (Sky130 analog cells)
+   - ⏸️ `rtl/periph/aes_sha_accel.sv` — AXI4 slave; AES-128 + SHA-256 pipeline
+
+2. **NPU (Minimal INT8 Inference Engine)**
+   - ⏸️ `rtl/npu/npu_top.sv` — AXI4 master (activations) + AXI4-Lite slave (config) + IRQ
+   - ⏸️ `rtl/npu/mac_array.sv` — 4×4 INT8 systolic MAC array (16 MACs, 64 ops/cycle)
+   - ⏸️ `rtl/npu/weight_buffer.sv` — 16 KB SRAM-backed weight store (DMA-loaded)
+   - ⏸️ `rtl/npu/activation_unit.sv` — ReLU; LUT-based sigmoid/tanh optional
+   - ⏸️ Phase 6 only if Phase 5 benchmarks reveal CPU/GPU bottleneck on ML workloads
+
+3. **Tech Node Exploration** (independent of RTL — P&R only)
+   - ⏸️ FreePDK45/NanGate45: run `make librelane-nangate45` (config already complete)
+   - ⏸️ ASAP7: create `pnr/asap7/config.json` + SDC (2.0–2.5 ns) + synthetic SRAM stubs; start with Phase 2 CPU (no SRAM macros needed); then Phase 3 with synthesised SRAM
 
 ## Questions?
 


### PR DESCRIPTION
Document the approved Phase 4 (GPU-Lite) and Phase 5 (SoC integration)
plans with full module lists, locked architecture decisions, workflow
steps, and next-step task lists so future sessions have complete context
to implement each phase without re-deriving design choices.

Locked decisions recorded:
- 16-byte cache lines stay for Phase 3; 32-byte reconsidered for L2 only
- Direct-mapped caches stay unless Phase 5 benchmarks prove conflict impact
- AXI4 burst upgrade deferred to Phase 5 (no Phase 3 FSM disruption)
- L2 cache deferred; add only if Phase 5 benchmarks justify it
- Behavioral SRAM model for Phase 5; real DRAM controller is Phase 6+ only

https://claude.ai/code/session_01JmYkiBqCpX4EF6ajZqmWHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised Phase 4/5 planned workflows with expanded scope for SoC integration (AXI4 crossbar, SRAM behavioral modeling, DMA/IRQ routing, cache/burst timing and verification/backend targets)
  * Added Phase 6+ outlook: additional AXI4‑Lite peripherals, optional minimal NPU, and tech‑node strategy with pnr targets and frequency assessments
  * Recorded locked architecture decisions and updated project structure and task checklists
<!-- end of auto-generated comment: release notes by coderabbit.ai -->