### PR TITLE
[Fix] Fix PDN -secondary_power GND mixing and I-cache AXI cancel race

### DIFF
--- a/pnr/asap7/pdn_asap7.tcl
+++ b/pnr/asap7/pdn_asap7.tcl
@@ -2,20 +2,27 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_global_connections.tcl
 set_global_connections
 
 set secondary []
-foreach vdd $::env(VDD_NETS) gnd $::env(GND_NETS) {
-    if { $vdd != $::env(VDD_NET)} {
+
+# Secondary VDD nets only — -secondary_power accepts power nets, not ground nets.
+foreach vdd $::env(VDD_NETS) {
+    if { $vdd != $::env(VDD_NET) } {
         lappend secondary $vdd
         set db_net [[ord::get_db_block] findNet $vdd]
-        if {$db_net == "NULL"} {
+        if { $db_net == "NULL" } {
             set net [odb::dbNet_create [ord::get_db_block] $vdd]
             $net setSpecial
             $net setSigType "POWER"
         }
     }
-    if { $gnd != $::env(GND_NET)} {
-        lappend secondary $gnd
+}
+
+# Secondary GND nets — create dbNets so PDN can reference them, but do NOT pass
+# these to -secondary_power (which accepts VDD nets only).  Route additional
+# ground domains via a separate set_voltage_domain -ground call when needed.
+foreach gnd $::env(GND_NETS) {
+    if { $gnd != $::env(GND_NET) } {
         set db_net [[ord::get_db_block] findNet $gnd]
-        if {$db_net == "NULL"} {
+        if { $db_net == "NULL" } {
             set net [odb::dbNet_create [ord::get_db_block] $gnd]
             $net setSpecial
             $net setSigType "GROUND"

--- a/rtl/mem/rv32i_dcache.sv
+++ b/rtl/mem/rv32i_dcache.sv
@@ -495,6 +495,15 @@ module rv32i_dcache (
                 end
 
                 // -----------------------------------------------------------------
+                // Cancel-race audit (2026-05-21): the stale-R-beat race that was
+                // fixed in rv32i_icache.sv does NOT apply here.  The D-cache has
+                // no cancel-on-!dc_valid_i branch in CS_REFILL, so ar_pending_q
+                // is never cleared while an R beat is still in flight.  The two
+                // state_q <= CS_IDLE exit paths (rresp-error below and bresp-error
+                // in CS_WRITEBACK) only fire when the respective handshake
+                // completes that same cycle, so no orphan beat is left in flight.
+                // If a dc_invalidate_i / flush path is ever added here, port the
+                // cancel_ar_q / cancel_wait_r_q fix from rv32i_icache.sv.
                 CS_REFILL: begin
                     if (!ar_pending_q) begin
                         if (axi_arready_i)

--- a/rtl/mem/rv32i_icache.sv
+++ b/rtl/mem/rv32i_icache.sv
@@ -170,6 +170,8 @@ module rv32i_icache (
     logic [31:0]                 refill_line_addr_q;
     logic [1:0]                  refill_word_q;
     logic                        ar_pending_q;
+    logic                        cancel_ar_q;       // AR mid-handshake after cancel — hold arvalid
+    logic                        cancel_wait_r_q;   // AR accepted after cancel — drain stale R beat
     logic [LINE_WORDS-1:0][31:0] refill_buf_q;   // Accumulates all 4 words
 
     // SRAM output pipeline registers — capture negedge-launched dout at posedge
@@ -243,7 +245,9 @@ module rv32i_icache (
     // AXI read control
     // =========================================================================
     assign axi_araddr_o  = {refill_line_addr_q[31:4], refill_word_q, 2'b00};
-    assign axi_arvalid_o = (state_q == CS_REFILL) && !ar_pending_q;
+    // cancel_ar_q holds arvalid asserted after a cancel until arready fires,
+    // satisfying AXI A3.2.1 (arvalid must not retract before arready).
+    assign axi_arvalid_o = ((state_q == CS_REFILL) && !ar_pending_q) || cancel_ar_q;
     assign axi_rready_o  = 1'b1;  // Always accept R responses (drains in-flight beats)
 
     // =========================================================================
@@ -329,12 +333,24 @@ module rv32i_icache (
             refill_line_addr_q <= '0;
             refill_word_q      <= 2'b00;
             ar_pending_q       <= 1'b0;
+            cancel_ar_q        <= 1'b0;
+            cancel_wait_r_q    <= 1'b0;
             refill_buf_q       <= '0;
         end else begin
+            // Background drain: advance cancel-drain flags independently of FSM state.
+            // AR completes after cancel → promote to wait-for-R.
+            if (cancel_ar_q && axi_arready_i) begin
+                cancel_ar_q     <= 1'b0;
+                cancel_wait_r_q <= !axi_rvalid_i;
+            end
+            // Stale R beat drains → safe to start a new refill.
+            if (cancel_wait_r_q && axi_rvalid_i)
+                cancel_wait_r_q <= 1'b0;
+
             case (state_q)
                 // -----------------------------------------------------------------
                 CS_IDLE: begin
-                    if (ic_valid_i && !ic_invalidate_i) begin
+                    if (!cancel_ar_q && !cancel_wait_r_q && ic_valid_i && !ic_invalidate_i) begin
                         // Issue SRAM read (combinational, above). Latch address and
                         // go to CS_SRAM_LATCH to capture SRAM output at next posedge.
                         ic_addr_q <= ic_addr_i;
@@ -381,6 +397,14 @@ module rv32i_icache (
                     // axi_rready_o=1'b1 drains any in-flight AXI beat without data loss.
                     if (ic_invalidate_i || !ic_valid_i) begin
                         state_q       <= CS_IDLE;
+                        // Determine which AXI drain mode is needed at cancel time:
+                        //   ar_pending_q=1, rvalid=0  → R still in flight, drain it
+                        //   ar_pending_q=1, rvalid=1  → R consumed this cycle, no drain
+                        //   ar_pending_q=0, arready=1 → AR just accepted, drain its R
+                        //   ar_pending_q=0, arready=0 → AR mid-handshake, hold arvalid
+                        cancel_ar_q     <= !ar_pending_q && !axi_arready_i;
+                        cancel_wait_r_q <= ( ar_pending_q && !axi_rvalid_i) ||
+                                           (!ar_pending_q &&  axi_arready_i && !axi_rvalid_i);
                         ar_pending_q  <= 1'b0;
                         refill_word_q <= 2'b00;
                     end else begin


### PR DESCRIPTION
Ticket #35 — pnr/asap7/pdn_asap7.tcl:
Split the combined foreach vdd/gnd loop into two separate loops so secondary GND nets are never passed to set_voltage_domain -secondary_power, which accepts VDD nets only. Behaviour is identical for the current single-supply config; future multi-supply configs will be API-correct.

Ticket #36 — rtl/mem/rv32i_icache.sv:
Add cancel_ar_q and cancel_wait_r_q flags to cover three races in the CS_REFILL cancel branch that the original ticket patch missed:
  - R arrives same cycle as cancel → old patch deadlocked; this fix does not wait (handshake completes this cycle).
  - AR accepted same cycle as cancel → old patch dropped the accepted AR and a stale R beat could corrupt the next refill.
  - AR still mid-handshake at cancel time → old patch violated AXI A3.2.1 (arvalid retract); cancel_ar_q holds axi_arvalid_o high until arready fires. CS_IDLE→CS_SRAM_LATCH is gated on both flags so no new refill starts until the outstanding AXI beat is fully drained.

Adjacent — rtl/mem/rv32i_dcache.sv:
Comment-only audit note: the same cancel race does not apply to the D-cache (no cancel-on-!dc_valid_i branch in CS_REFILL).

Verification: Verilator lint clean; all CPU integration tests pass including 5 Phase 3 cache integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved I-cache refill-cancel logic to correctly handle AXI handshake timing during cancellations, including proper tracking and draining of in-flight transactions.

* **Chores**
  * Refined power delivery network configuration for secondary voltage domains.
  * Added internal documentation clarifying D-cache refill behavior differences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chuanseng-ng/claude_verilog_test/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->