### PR TITLE
[Doc] Sync docs to Phase 4 GPU-Lite completion + Phase 5 M3 crossbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ See `docs/ROADMAP.md` for complete phase plan and `docs/PHASE_STATUS.md` for cur
 
 **Tech node progression**: Sky130 → FreePDK45/NanGate45 → ASAP7 (see Technology Node Strategy below)
 
-### Phase 4: GPU-Lite SIMT Engine (Planned)
+### Phase 4: GPU-Lite SIMT Engine (✅ COMPLETE 2026-05-27)
 
 - **ISA**: Custom 32-bit vector encoding — VADD, VSUB, VMUL, VAND, VOR, VSLL, VLD, VST, VBEQ, VBNE, VJMP, VRET, VSYNC
 - **Execution**: Single compute unit; 8 SIMD lanes; 8 warps max; 64 total threads

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This project incrementally builds a fully functional SoC through 6 phases:
 2. **Phase 1**: Minimal RV32I CPU (single-cycle) ✅ **COMPLETE** (2026-02-13)
 3. **Phase 2**: Pipelined CPU (5-stage + interrupts) ✅ **COMPLETE** (2026-03-08)
 4. **Phase 3**: Memory System (I-cache + D-cache) ✅ **COMPLETE** (2026-05-21)
-5. **Phase 4**: GPU-Lite Compute Engine (SIMT) ⏸️ Not Started
-6. **Phase 5**: SoC Integration (peripherals, boot ROM)
+5. **Phase 4**: GPU-Lite Compute Engine (SIMT) ✅ **COMPLETE** (2026-05-27)
+6. **Phase 5**: SoC Integration (peripherals, boot ROM) ⏸️ Not Started
 
-## Current Status: Phase 4 (Not Started) — Phase 3 Complete
+## Current Status: Phase 5 (SoC Integration) — Not Started; Phase 4 Complete
 
 **Phase 0 Complete** ✅ (2026-01-18):
 
@@ -51,6 +51,13 @@ This project incrementally builds a fully functional SoC through 6 phases:
 - ✅ Cache arbiter: D$ priority over I$ (D-write > D-read > I-read)
 - ✅ Verification: I-cache 7/7, D-cache 8/8, integration 5/5; **139/139 full regression**
 - ✅ PPA sign-off (ASAP7 7nm, Run 43, 2026-05-20): **1418 MHz / 27.27 mW / 3,844 µm²**, 0 DRC, 0 antenna
+
+**Phase 4 Complete** ✅ (2026-05-27):
+
+- ✅ 9/9 GPU-Lite RTL modules (`rtl/gpu/`): top, command queue, warp scheduler, compute unit, vector regfile, vector ALU, memory unit, coalescer, shared memory
+- ✅ SIMT execution: 8-lane warps, round-robin scheduler, single-level divergence stack, 16 KB / 32-bank shared memory
+- ✅ Verification: GPU unit + kernel tests green; CPU re-gate 140/140 + 100k random; 1,000-kernel random regression, 0 deadlocks/mismatches
+- ✅ PPA sign-off (ASAP7 7nm, Run `RUN_2026-05-28_06-29-48`): **571 MHz (1.75 ns) / 262 mW / 115,600 µm² die / 60,500 µm² stdcell**, Setup WS +197.3 ps, Hold WS +16.3 ps (0 viol), 0 antenna
 
 ## Implemented Features
 
@@ -111,7 +118,7 @@ This project incrementally builds a fully functional SoC through 6 phases:
 │   │   │   └── ...
 │   │   ├── rv32i_cpu_top.sv      # Top-level with AXI4-Lite + APB3
 │   │   └── rv32i_axi_arbiter.sv  # IF/MEM priority arbiter
-│   ├── gpu/                      # (Phase 4 - not started)
+│   ├── gpu/                      # ✅ Phase 4 GPU-Lite (9 modules; ASAP7 571 MHz signoff)
 │   ├── mem/                      # ✅ Phase 3 caches (~1,424 lines)
 │   │   ├── rv32i_cache_pkg.sv    # Cache parameters and types
 │   │   ├── rv32i_icache.sv       # I-cache (4 KB, direct-mapped, FENCE.I)
@@ -126,12 +133,12 @@ This project incrementally builds a fully functional SoC through 6 phases:
 
 ## Requirements
 
-### Phase 0 (Current)
+### Reference Models & Tests
 
 - **Python** 3.8+ with pytest
 - **cocotb** (for test infrastructure setup)
 
-### Phase 1+ (Future)
+### RTL Simulation & Backend
 
 - **Verilator** (5.x recommended)
 - **GCC/G++** with C++17 support

--- a/docs/PHASE3_CLOSURE_AND_PHASE4_PLAN.md
+++ b/docs/PHASE3_CLOSURE_AND_PHASE4_PLAN.md
@@ -361,6 +361,9 @@ LibreLane-driven incremental campaign Phase 2+3 used (Runs 7→43).
 | `pnr/asap7/gpu/pdn.tcl` | Power grid for GPU block. |
 
 ### To modify
+
+> **✅ COMPLETED (2026-05-27)**: This is a historical planning checklist — Phase 4 is now done. All status-marker actions below are closed: Phase 3 → ✅, Phase 4 → ✅ COMPLETE (ASAP7 571 MHz sign-off). No further action required from this table.
+
 | Path | Why |
 |---|---|
 | `CLAUDE.md` | Add doc link to golden spec; update Phase 3 ✅ status; update Phase 4 status from ⏸️ to 🔄 once started. |

--- a/docs/PHASE_STATUS.md
+++ b/docs/PHASE_STATUS.md
@@ -441,38 +441,34 @@ All previous specification issues have been resolved:
 
 ## Next Actions
 
-### Immediate — Phase 4 GPU-Lite RTL Implementation
+### Immediate — Phase 5 SoC Integration
 
-**Phase 3 COMPLETE** ✅ 139/139 tests passing, all exit criteria met (2026-05-21).
+**Phase 4 COMPLETE** ✅ all GPU tests green, 1,000-kernel random regression pass, ASAP7 571 MHz PD sign-off (2026-05-27). See Phase 4 section above and `docs/GPU_ASAP7_RUN_HISTORY.md`.
 
-**Current Priority**: Phase 4 GPU-Lite SIMT compute engine.
-See `docs/PHASE3_CLOSURE_AND_PHASE4_PLAN.md` for the full implementation plan (golden spec).
-Key decisions: AXI4-Lite slave for control (not APB3), shared_memory.sv in scope, ASAP7 PD sign-off required.
+**Current Priority**: Phase 5 SoC integration (CPU + GPU + DMA + AXI4 crossbar + peripherals).
+See `docs/PHASE5_SOC_INTEGRATION_PLAN.md` for the full M1–M12 milestone roadmap (golden spec).
+Key decisions: AXI4 crossbar data fabric + AXI-Lite control bus, Phase 3 cache refill FSMs upgraded to AXI4 burst, behavioral AXI4-slave SRAM, ASAP7 SoC PD sign-off required.
 
-1. **New RTL Modules** (10 files, `rtl/gpu/`):
-   - 🔄 `gpu_pkg.sv` — package: constants, structs, opcode enums (lint-clean ✅)
-   - ⏸️ `vector_register_file.sv` — 32 regs × 8 lanes × 8 warps
-   - ⏸️ `vector_alu.sv` — VADD/VSUB/VMUL/VAND/VOR/VXOR/VSLL/VSRL/VSRA + imm forms (8 lanes)
-   - ⏸️ `gpu_compute_unit.sv` — 4-stage FETCH/DECODE/EX/WB + divergence stack
-   - ⏸️ `warp_scheduler.sv` — round-robin; warp state: warp_id, PC, active_mask, div_stack
-   - ⏸️ `gpu_command_queue.sv` — kernel descriptor FIFO (1-deep in Phase 4)
-   - ⏸️ `gpu_memory_unit.sv` — per-lane address gen; VLD/VST → coalescer
-   - ⏸️ `memory_coalescer.sv` — 8-lane requests → AXI4 single-beat transactions
-   - ⏸️ `shared_memory.sv` — 16 KB scratchpad, 32 banks, bank-conflict serialisation
-   - ⏸️ `gpu_top.sv` — AXI4-Lite slave (control regs) + AXI4 master (memory) + gpu_irq
+1. **AXI4 Interconnect** (build first — prerequisite for integration):
+   - ⏸️ `rtl/soc/axi4_crossbar.sv` — N-master M-slave data fabric
+   - ⏸️ `rtl/soc/axi_lite_interconnect.sv` — control bus
+   - ⏸️ `rtl/soc/axi_lite_register_bank.sv` — GPU + DMA config registers
+   - ⏸️ Upgrade Phase 3 refill FSMs from 4 sequential AXI4-Lite beats to AXI4 burst mode
 
-2. **Verification** (follows RTL completion per group):
-   - ⏸️ Unit tests: `tb/cocotb/gpu/test_vector_regfile.py`, `test_vector_alu.py`,
-     `test_divergence.py`, `test_warp_scheduler.py`, `test_command_queue.py`,
-     `test_memory_coalescer.py`, `test_shared_memory.py`
-   - ⏸️ Kernel tests: vector add, dot product, divergence, coalescing, shared-mem ping-pong, VSYNC
-   - ⏸️ CPU-GPU handoff integration test
-   - ⏸️ 1,000 random kernel regression
-   - ⏸️ Phase 3 regression re-run (139 tests must still pass)
+2. **Peripherals + DMA + SRAM**:
+   - ⏸️ `rtl/periph/dma_engine.sv`, `uart_controller.sv`, `spi_controller.sv`, `timer.sv`, `interrupt_controller.sv`
+   - ⏸️ `rtl/soc/sram_controller.sv` — behavioral AXI4-slave SRAM (no DRAM refresh)
+   - ⏸️ `rtl/soc/soc_top.sv` — full SoC top-level; CSR-mapped performance counters
 
-3. **Physical Design** (follows verification):
-   - ⏸️ ASAP7 GPU block synthesis + P&R + STA (`pnr/asap7/gpu/`)
-   - ⏸️ Target: ≥ 1418 MHz (705 ps), WNS ≥ 0, 0 DRC, 0 antenna
+3. **Verification**:
+   - ⏸️ CPU-GPU integration: kernel launch → interrupt → result read
+   - ⏸️ Software coherency: CPU D-cache flush → GPU kernel → CPU D-cache invalidate
+   - ⏸️ DMA transfer tests; full CPU + GPU benchmark suite
+   - ⏸️ L2 cache decision — add `rtl/mem/l2_cache.sv` only if L1 miss rates justify it
+
+4. **Physical Design**:
+   - ⏸️ Full SoC synthesis + P&R + STA; `pnr/constraints/phase5_soc.sdc`, `phase5_soc.upf`
+   - ⏸️ Power domain validation (PD_CPU, PD_GPU, PD_SRAM, PD_PERIPH)
 
 ## Documentation Structure
 
@@ -483,7 +479,7 @@ docs/
 ├── design/
 │   ├── PHASE0_ARCHITECTURE_SPEC.md   # Phase 0 CPU specification
 │   ├── PHASE1_ARCHITECTURE_SPEC.md   # Phase 1 CPU specification (verified 2026-02-13)
-│   ├── PHASE4_GPU_ARCHITECTURE_SPEC.md # Phase 4 GPU specification (TBD)
+│   ├── PHASE4_GPU_ARCHITECTURE_SPEC.md # Phase 4 GPU specification (frozen, ✅ complete)
 │   ├── DESIGN_EXPECTATION.md         # High-level design goals
 │   ├── RTL_DEFINITION.md             # Interface definitions
 │   ├── GPU_MODEL.md                  # GPU execution model overview


### PR DESCRIPTION
## Summary

Brings stale top-level documentation in line with the **Phase 4 GPU-Lite completion** (2026-05-27, ASAP7 571 MHz sign-off) and bundles the already-committed **Phase 5 M3 AXI4 crossbar** foundation on this branch.

A repo-wide sweep (133 markdown files) found 4 docs still marking Phase 4 as *Not Started* / *Planned* / placeholder, contradicting the authoritative completion records (`PHASE_STATUS.md` L212–254, `GPU_ASAP7_RUN_HISTORY.md`, `PHASE4_PROGRESS.md`). This PR makes every status doc consistently show **Phase 4 = ✅ COMPLETE** and **Phase 5 = current/next**.

## Commits

- `[Feature] Phase 5 M3: AXI4 crossbar + M1 AXI package foundation` (pre-existing on branch)
- `[Doc] Sync stale docs to Phase 4 GPU-Lite completion` (this change)

## Doc changes

| File | Change |
|------|--------|
| `README.md` | Phase list L16 `⏸️ Not Started`→`✅ COMPLETE`; Current Status → Phase 5; added Phase 4 Complete bullet block (571 MHz signoff); fixed `rtl/gpu/` tree label; dropped stale `(Current)`/`(Future)` requirement headers |
| `CLAUDE.md` | Phase 4 section header `(Planned)` → `(✅ COMPLETE 2026-05-27)` |
| `docs/PHASE_STATUS.md` | "Next Actions" rewritten Phase 4 → Phase 5 SoC (crossbar / peripherals / SoC top, points to `PHASE5_SOC_INTEGRATION_PLAN.md`); spec `(TBD)` → `(frozen, ✅ complete)` |
| `docs/PHASE3_CLOSURE_AND_PHASE4_PLAN.md` | ✅ COMPLETED banner on historical "To modify" checklist |

No new figures invented — reused authoritative **571 MHz / 262 mW / 115,600 µm² die** from `PHASE_STATUS.md` and run `RUN_2026-05-28_06-29-48`.

## Test plan

- [x] `grep -rn "Phase 4.*Not Started\|GPU-Lite SIMT Engine (Planned)\|(TBD)"` → 0 stale hits
- [x] Manual scan: README L16/L19, CLAUDE.md L80 read as ✅ COMPLETE
- [x] No figure drift vs `PHASE_STATUS.md` L243–246
- Docs-only for the new commit; no RTL/test/PD changes. M3 crossbar RTL already verified on branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)