### PR TITLE
[Feature] Phase 5 M6: behavioral AXI4-slave SRAM controller (+ review hardening)

### DIFF
--- a/rtl/soc/sram_controller.sv
+++ b/rtl/soc/sram_controller.sv
@@ -94,6 +94,23 @@ module sram_controller
         return (addr >= SRAM_BASE) && (addr <= SRAM_LIMIT);
     endfunction
 
+    // Last-beat byte address for a burst.  For INCR, the final beat starts at
+    // base + len*4 (AxSIZE fixed at 4 B in this SoC).  For FIXED/WRAP the
+    // address does not advance past the start beat — use base so the caller's
+    // in_range(last) check is identical to in_range(base).
+    // Note: WRAP is already rejected by the burst-type check; returning base
+    // here is conservative but correct.
+    function automatic logic [AW-1:0] last_addr(
+        input logic [AW-1:0]   base,
+        input logic [LENW-1:0] len,
+        input logic [1:0]      burst
+    );
+        if (burst == AXI_BURST_INCR)
+            return base + (AW'(len) << 2);
+        else
+            return base;
+    endfunction
+
     // ── Write FSM ────────────────────────────────────────────────────────────
     typedef enum logic [1:0] {W_IDLE, W_DATA, W_RESP} wstate_e;
     wstate_e          wstate;
@@ -113,20 +130,24 @@ module sram_controller
                     if (s_awvalid) begin
                         w_idx  <= word_index(s_awaddr);
                         bid_q  <= s_awid;
-                        w_err  <= ~in_range(s_awaddr) || (s_awburst == AXI_BURST_WRAP);
+                        w_err  <= ~in_range(s_awaddr)
+                                  || ~in_range(last_addr(s_awaddr, s_awlen, s_awburst))
+                                  || (s_awburst == AXI_BURST_WRAP);
                         w_incr <= (s_awburst == AXI_BURST_INCR);
                         wstate <= W_DATA;
                     end
                 end
                 W_DATA: begin
                     if (s_wvalid) begin
-                        for (int b = 0; b < SW; b++) begin
-                            if (s_wstrb[b]) begin
-                                mem[w_idx][b*8 +: 8] <= s_wdata[b*8 +: 8];
+                        if (!w_err) begin
+                            for (int b = 0; b < SW; b++) begin
+                                if (s_wstrb[b]) begin
+                                    mem[w_idx][b*8 +: 8] <= s_wdata[b*8 +: 8];
+                                end
                             end
-                        end
-                        if (w_incr) begin
-                            w_idx <= w_idx + 1'b1;
+                            if (w_incr) begin
+                                w_idx <= w_idx + 1'b1;
+                            end
                         end
                         if (s_wlast) begin
                             wstate <= W_RESP;
@@ -170,7 +191,9 @@ module sram_controller
                         r_idx  <= word_index(s_araddr);
                         r_cnt  <= s_arlen;
                         rid_q  <= s_arid;
-                        r_err  <= ~in_range(s_araddr) || (s_arburst == AXI_BURST_WRAP);
+                        r_err  <= ~in_range(s_araddr)
+                                  || ~in_range(last_addr(s_araddr, s_arlen, s_arburst))
+                                  || (s_arburst == AXI_BURST_WRAP);
                         r_incr <= (s_arburst == AXI_BURST_INCR);
                         rstate <= R_DATA;
                     end
@@ -203,6 +226,6 @@ module sram_controller
     // AxSIZE is fixed at 4 B for this 32-bit SoC; AWLEN is implied by WLAST on
     // the write path.  Sink them to keep Verilator -Wall clean.
     logic _unused_ok;
-    assign _unused_ok = &{1'b0, s_awsize, s_arsize, s_awlen};
+    assign _unused_ok = &{1'b0, s_awsize, s_arsize};
 
 endmodule

--- a/tb/cocotb/soc/Makefile
+++ b/tb/cocotb/soc/Makefile
@@ -80,7 +80,7 @@ export COCOTB_REDUCED_LOG_FMT=1
 
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
-.PHONY: crossbar register_bank axil_interconnect sram_controller soc_all
+.PHONY: crossbar register_bank axil_interconnect sram_controller soc_all verilator_lint
 crossbar:
 	$(MAKE) MODULE=test_crossbar TOPLEVEL=tb_axi4_crossbar
 
@@ -92,7 +92,11 @@ axil_interconnect:
 	$(MAKE) MODULE=test_axil_interconnect TOPLEVEL=tb_axi_lite_interconnect \
 		VERILOG_SOURCES="$(AXIL_SOURCES)"
 
-sram_controller:
+verilator_lint:
+	verilator --lint-only -Wall -Wno-IMPORTSTAR \
+		--top-module sram_controller $(SRAM_SOURCES)
+
+sram_controller: verilator_lint
 	$(MAKE) MODULE=test_sram_controller TOPLEVEL=sram_controller \
 		VERILOG_SOURCES="$(SRAM_SOURCES)"
 

--- a/tb/cocotb/soc/test_sram_controller.py
+++ b/tb/cocotb/soc/test_sram_controller.py
@@ -24,8 +24,9 @@ RESP_SLVERR = 0b10
 SIZE_4B = 0b010
 BURST_INCR = 0b01
 
-SRAM_BASE = 0x0000_2000
-OOR_ADDR  = 0x0000_1000   # below SRAM window -> SLVERR
+SRAM_BASE  = 0x0000_2000
+SRAM_LIMIT = 0x0FFF_FFFF   # inclusive top of SRAM window
+OOR_ADDR   = 0x0000_1000   # below SRAM window -> SLVERR
 
 
 async def _setup(dut):
@@ -234,3 +235,47 @@ async def test_back_to_back_bursts(dut):
     assert d0 == w0, f"burst0 mismatch {[hex(d) for d in d0]}"
     assert d1 == w1, f"burst1 mismatch {[hex(d) for d in d1]}"
     dut._log.info("test_back_to_back_bursts PASS")
+
+
+# ── Test 7: INCR burst that crosses SRAM_LIMIT returns SLVERR ────────────────
+
+@cocotb.test()
+async def test_burst_crosses_limit_slverr(dut):
+    """4-beat INCR burst starting near SRAM_LIMIT whose last beat exceeds the
+    window boundary must return SLVERR on both write and read.
+
+    Start address: SRAM_LIMIT - 0xB, aligned down to 4 B = 0x0FFF_FFF4.
+      Beat 0: 0x0FFF_FFF4  (inside  window)
+      Beat 1: 0x0FFF_FFF8  (inside  window)
+      Beat 2: 0x0FFF_FFFC  (inside  window)
+      Beat 3: 0x1000_0000  (OUTSIDE window -> burst crosses limit)
+    The RTL full-span check (last_addr = base + len*4) must catch this and
+    assert w_err / r_err, producing SLVERR on the B and R channels.
+    """
+    m = await _setup(dut)
+
+    # Word-aligned start address inside the SRAM window, close to the top.
+    # last beat byte address = start + 3*4 = 0x0FFF_FFF4 + 0xC = 0x1000_0000
+    # which exceeds SRAM_LIMIT (0x0FFF_FFFF).
+    start = (SRAM_LIMIT - 0xB) & ~0x3   # 0x0FFF_FFF4
+
+    dut._log.info(
+        f"test_burst_crosses_limit_slverr: start=0x{start:08X} "
+        f"last_beat=0x{start + 3*4:08X} SRAM_LIMIT=0x{SRAM_LIMIT:08X}"
+    )
+
+    # Write: 4-beat INCR burst crossing the window end -> expect SLVERR.
+    bresp = await m.write(start, [0xDEAD_0001, 0xDEAD_0002, 0xDEAD_0003, 0xDEAD_0004])
+    assert bresp == RESP_SLVERR, (
+        f"crossing-burst write resp {bresp:#x} != SLVERR (0x{RESP_SLVERR:x}); "
+        "RTL full-span range check may be missing"
+    )
+
+    # Read: same burst -> expect SLVERR.
+    _, rresp = await m.read(start, length=4)
+    assert rresp == RESP_SLVERR, (
+        f"crossing-burst read resp {rresp:#x} != SLVERR (0x{RESP_SLVERR:x}); "
+        "RTL full-span range check may be missing"
+    )
+
+    dut._log.info("test_burst_crosses_limit_slverr PASS")


### PR DESCRIPTION
## Summary

Phase 5 milestone **M6** — behavioral AXI4-slave SRAM controller — plus review-driven hardening. Bundles both M6 commits (controller branch has no PR; this branch is a superset).

- **`rtl/soc/sram_controller.sv`** (new): burst-capable AXI4 slave backing main memory (`soc_addr_map_pkg` SRAM window `0x0000_2000–0x0FFF_FFFF`). Behavioral flat word array, no DRAM refresh. Two single-outstanding FSMs (write/read). INCR+FIXED bursts, WSTRB byte enables, BID/RID echo, WRAP/out-of-range → SLVERR.
- **`tb/cocotb/soc/test_sram_controller.py`** (new): 7-test cocotb suite (BFM `AXI4Master`), mirroring M3 SoC test conventions.
- **`tb/cocotb/soc/Makefile`**: `sram_controller` target + `soc_all` entry + `verilator_lint` gate (warnings fatal) as prerequisite.

## Review hardening (commit 2)

- **Full-span burst range check** (AW + AR): reject INCR bursts whose *last* beat walks past `SRAM_LIMIT`, not just the start address (`last_addr()` helper).
- **No state commit on errored write**: mem writes + index increment guarded by `!w_err`; FSM still drains beats and returns SLVERR.
- **New regression** `test_burst_crosses_limit_slverr`: 4-beat INCR from `0x0FFF_FFF4` (last beat `0x1000_0000`) → SLVERR on write and read.

### Review items intentionally skipped (invalid vs current code)
- **pyuvm refactor** — sibling SoC tests are raw cocotb/BFM; no pyuvm in `tb/cocotb/soc/`. Out of scope / inconsistent.
- **`P_` param prefix** — repo convention is plain `AW/DW/SW/IW/LENW` (`axi4_crossbar.sv`, `axi_lite_register_bank.sv`).
- **`make help`** — no help target in these Makefiles; header + target list already document `sram_controller`/`soc_all`.

## Test plan

- [x] Verilator `-Wall` lint clean (0 errors / 0 warnings)
- [x] `make -C tb/cocotb/soc sram_controller` → **7/7 PASS** (single + burst rw, WSTRB partial, ID echo, OOR SLVERR, back-to-back bursts, burst-crosses-limit SLVERR)
- [x] `verilator_lint` prerequisite runs and gates the build

Closes M6 (`claude_verilog_test-69y`). Unblocks M7 crossbar data sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)