### PR TITLE
Add CDC check infrastructure (cdc_snitch POC, parked/informational)

### DIFF
--- a/docs/verification/CDC_SNITCH_POC.md
+++ b/docs/verification/CDC_SNITCH_POC.md
@@ -27,7 +27,7 @@ clock domain.**
 
 ## Toolchain (what actually worked)
 
-```
+```text
 sv2v (SystemVerilog -> Verilog-2005)  ->  yosys (flatten -> JSON)  ->  cdc_snitch.py
 ```
 
@@ -44,7 +44,7 @@ explicitly for the CDC flow.)
 
 ## Result (full `soc_top`, 52 RTL files, ~32k registers)
 
-```
+```text
 OK1: 18249   CDC: 0   OKX: 8653   BAD: 5234
 ```
 

--- a/docs/verification/CDC_SNITCH_POC.md
+++ b/docs/verification/CDC_SNITCH_POC.md
@@ -1,0 +1,94 @@
+# CDC Snitch integration — feasibility POC
+
+**Status:** parked / informational (2026-06-09)
+**Tool:** [BerkeleyLab/Bedrock `cdc_snitch`](https://github.com/BerkeleyLab/Bedrock/blob/master/build-tools/cdc_snitch.md) (pinned commit `8929d4d`)
+**Runner:** `make -C sim cdc` → `tools/cdc/` (see [`tools/cdc/README.md`](../../tools/cdc/README.md))
+
+## Goal
+
+Evaluate whether Berkeley Lab's open-source `cdc_snitch` can detect clock-domain-crossing
+(CDC) issues in this RV32I + GPU-lite SoC and serve as a CI gate.
+
+## What cdc_snitch does
+
+A small Python tool that runs Verilog through **yosys** (≥0.23), flattens the design to
+gates/memories, writes a JSON netlist, and classifies every register by whether its
+data-source clock domains match its own clock:
+
+| Category | Meaning |
+| -------- | ------- |
+| `OK1` | all inputs in the register's own domain (normal logic) |
+| `CDC` | single-source crossing through trivial logic, marked `magic_cdc` (intentional) |
+| `OKX` | single-source crossing, not marked (e.g. an input-sampling flop) |
+| `BAD` | a register's data combines **multiple** clock domains (the dangerous anti-pattern) |
+
+Non-zero `BAD` → non-zero exit code. **Every top-level input port is treated as its own
+clock domain.**
+
+## Toolchain (what actually worked)
+
+```
+sv2v (SystemVerilog -> Verilog-2005)  ->  yosys (flatten -> JSON)  ->  cdc_snitch.py
+```
+
+Front-end finding: **pure oss-cad-suite could not parse this RTL.**
+- yosys built-in `read_verilog -sv` → syntax error on package-import-in-package
+  (`soc_addr_map_pkg.sv`).
+- the bundled `slang` plugin → rejects the **frozen** Phase 3 cache RTL's mixed
+  blocking/non-blocking writes to `valid_array`/`dirty_array` (`rv32i_dcache.sv`).
+
+Adding **sv2v** as a preprocessor resolves both with **zero RTL changes**. (Two unrelated
+nits were worked around in the flow: `axi_lite_register_bank.sv` is absent from the
+Verilator `SOC_TOP_SOURCES` list because Verilator auto-discovers it — it is added back
+explicitly for the CDC flow.)
+
+## Result (full `soc_top`, 52 RTL files, ~32k registers)
+
+```
+OK1: 18249   CDC: 0   OKX: 8653   BAD: 5234
+```
+
+- ✅ The toolchain runs end-to-end and elaborates the **entire** SoC to a netlist.
+- ✅ It **correctly recognized the real async input** `uart_rx_i`: 0 `BAD`, classified
+  `OKX` (the 2-FF synchronizer in `uart_controller.sv` is seen). So it *would* catch a
+  *missing* synchronizer.
+
+### The 5234 `BAD` are ~100% false positives
+
+Because cdc_snitch models every top-level input port as a separate clock domain, and this
+SoC is **single-clock** (`soc_top` fans one `clk_i`/`rst_n_i` pair to everything):
+
+| Foreign "domain" flagged | BAD registers | Reality |
+| ------------------------ | ------------- | ------- |
+| `rst_n_i` (async reset)  | ~4997 (95%)   | reset, not a clock domain |
+| `apb_paddr_i` + APB ctrl | ~235          | APB debug bus, synchronous to `clk_i` |
+| `spi_miso_i`             | 2             | SPI MISO sampled in `clk_i` domain (master mode) |
+
+There are **zero genuine internal multi-clock crossings** — correct, because there is only
+one clock. The one mildly interesting hit is `u_spi.rx_shift_q` / `rx_push_data` sampling
+`spi_miso_i` without a 2-FF synchronizer; harmless in master mode but worth tracking as a
+hardening opportunity (to be filed in beads — see "Follow-ups" below).
+
+## Follow-ups
+
+- **SPI MISO hardening:** evaluate adding a 2-FF synchronizer on `spi_miso_i` in
+  `rtl/periph/spi_controller.sv` (`u_spi.rx_shift_q` / `rx_push_data`). Not a functional
+  bug in master mode, but good CDC hygiene. File as a beads issue (`bd create`).
+
+## Decision
+
+**Park as a documented, informational tool.** Committed:
+- `tools/cdc/` — pinned fetch (`fetch_cdc_tools.sh`, `versions.env`) + runner (`run_cdc.sh`).
+- `make -C sim cdc` — informational by default; `make cdc CDC_STRICT=1` gives gate semantics.
+
+**No CI gate yet.** As-is it is a permanently-red gate drowning in false positives.
+
+## To make it a real gate (deferred to Phase 6+)
+
+When real multiple clock domains are introduced, add a thin CDC verification wrapper that:
+1. neutralizes the async-reset domain (synchronize reset internally / exclude `rst_n_i`),
+2. declares the genuinely-synchronous top-level inputs (APB debug, SPI) as `clk_i`-domain
+   (register them once before use, since cdc_snitch has no port-domain allowlist),
+3. marks intentional crossings with the `magic_cdc` attribute (→ `CDC` instead of `OKX`).
+
+The residual output then becomes meaningful and `BAD=0` can gate CI.

--- a/docs/verification/VERIFICATION_PLAN.md
+++ b/docs/verification/VERIFICATION_PLAN.md
@@ -403,10 +403,17 @@ RTL Verification (cocotb + pyuvm)
 | Test Category | Description | Tool | AI/Human |
 | :-----------: | :---------: | :--: | :------: |
 | Synthesis lint | Check for synthesis warnings | Yosys | AI may run, **Human reviews** |
+| CDC check | Clock-domain-crossing anti-patterns (`make cdc`) | Bedrock cdc_snitch (sv2v→yosys) | AI may run, **Human reviews** |
 | Timing analysis | Check setup/hold violations | OpenSTA | **Human analyzes** |
 | Power analysis | Validate power budget | OpenROAD | **Human analyzes** |
 | DRC/LVS | Physical verification | KLayout | **Human reviews** |
 | Gate-level sim | Functional + timing verification | Verilator | **Human validates** |
+
+> **CDC check note:** `make -C sim cdc` runs Bedrock's `cdc_snitch` (sv2v → yosys → analysis).
+> It is **informational / parked** — on the current single-clock SoC its `BAD` count is
+> dominated by false positives (the async reset and synchronous APB/SPI ports are each
+> modeled as a separate clock domain). It becomes a real `BAD=0` gate at Phase 6+ once
+> actual clock domains exist. Full writeup: [`CDC_SNITCH_POC.md`](CDC_SNITCH_POC.md).
 
 **AI may assist with**:
 

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -194,6 +194,7 @@ help:
 	@echo "  make waves        - Open waveform viewer (gtkwave)"
 	@echo "  make lint         - Run Verilator lint check (CPU top + chains lint_soc)"
 	@echo "  make lint_soc     - Run Verilator lint check for soc_top (Phase 5 M8)"
+	@echo "  make cdc          - Run Bedrock cdc_snitch CDC check (informational; CDC_STRICT=1 to gate)"
 	@echo "  make soc_boot     - Run Phase 5 M9 SoC boot test (PC scoreboard + 100/100 stability)"
 	@echo "  make soc_all      - Run all SoC component + boot tests (M3-M6 + M9)"
 	@echo "  make axi          - Run AXI protocol tests only"
@@ -331,6 +332,30 @@ lint_soc:
 # SYNCASYNCNET waived at SoC top: leaf blocks use heterogeneous reset
 # disciplines (CPU synchronous per ASIC rule, peripherals async); soc_top only
 # distributes the shared rst_n_i. Frozen leaf RTL — not a SoC integration bug.
+
+# ============================================================================
+# CDC check — BerkeleyLab/Bedrock cdc_snitch (informational; see tools/cdc/)
+# ============================================================================
+# sv2v -> yosys (flatten) -> cdc_snitch.py. Parked / informational on this
+# single-clock SoC (BAD count is dominated by false positives: async reset +
+# synchronous APB/SPI ports modeled as separate clock domains). Run as a gate
+# with `make cdc CDC_STRICT=1`. Full writeup: docs/verification/CDC_SNITCH_POC.md
+CDC_DIR     := $(PROJ_ROOT)/sim/build/cdc
+CDC_STRICT  ?= 0
+# SOC_TOP_SOURCES plus axi_lite_register_bank.sv (Verilator auto-discovers it;
+# sv2v/yosys need it listed explicitly).
+CDC_SOURCES := $(SOC_TOP_SOURCES) $(RTL_DIR)/soc/axi_lite_register_bank.sv
+
+.PHONY: cdc
+cdc:
+	@bash $(PROJ_ROOT)/tools/cdc/fetch_cdc_tools.sh
+	@mkdir -p $(CDC_DIR)
+	@printf '%s\n' $(CDC_SOURCES) > $(CDC_DIR)/soc_top.flist
+	@CDC_CACHE="$(CDC_DIR)" \
+	 CDC_FLIST="$(CDC_DIR)/soc_top.flist" \
+	 CDC_INCDIRS="$(RTL_DIR)/cpu/core $(RTL_DIR)/mem $(RTL_DIR)/soc $(RTL_DIR)/gpu $(RTL_DIR)/periph" \
+	 CDC_TOP=soc_top CDC_STRICT=$(CDC_STRICT) \
+	 bash $(PROJ_ROOT)/tools/cdc/run_cdc.sh
 
 # ============================================================================
 # Cocotb Targets (require cocotb installation in WSL)

--- a/tools/cdc/README.md
+++ b/tools/cdc/README.md
@@ -1,0 +1,76 @@
+# CDC check — BerkeleyLab/Bedrock `cdc_snitch`
+
+Clock-domain-crossing (CDC) static check for the SoC RTL, using the open-source
+[`cdc_snitch`](https://github.com/BerkeleyLab/Bedrock/blob/master/build-tools/cdc_snitch.md)
+tool from Berkeley Lab's Bedrock project.
+
+**Status: parked / informational.** Wired up and proven to run on the full
+`soc_top`, but **not a CI gate** — see "Why it's informational" below and the
+full POC writeup in [`docs/verification/CDC_SNITCH_POC.md`](../../docs/verification/CDC_SNITCH_POC.md).
+
+## How it works
+
+```
+sv2v (SystemVerilog -> Verilog-2005)  ->  yosys (flatten to gates/mem -> JSON)  ->  cdc_snitch.py
+```
+
+`cdc_snitch.py` walks the flattened netlist and classifies every register by
+whether its data-source clock domains match its own clock:
+
+| Category | Meaning |
+| -------- | ------- |
+| `OK1` | all inputs in the register's own domain (normal logic) |
+| `CDC` | single-source crossing through trivial logic, marked `magic_cdc` (intentional) |
+| `OKX` | single-source crossing, *not* marked (e.g. an input-sampling flop) |
+| `BAD` | a register's data combines **multiple** clock domains (the dangerous anti-pattern) |
+
+`cdc_snitch` treats **every top-level input port as its own clock domain**.
+
+## Usage
+
+```bash
+# from the repo root
+cd sim
+make cdc                 # fetch tools (if needed) + run, informational
+make cdc CDC_STRICT=1    # same, but exit non-zero if BAD>0 (gate semantics)
+```
+
+Or directly:
+
+```bash
+tools/cdc/fetch_cdc_tools.sh             # cdc_snitch + sv2v (yosys assumed on PATH)
+tools/cdc/fetch_cdc_tools.sh --with-yosys  # also download oss-cad-suite (~700 MB)
+```
+
+Tools land in the git-ignored `sim/build/cdc/`; pinned versions are in
+[`versions.env`](versions.env). The report is `sim/build/cdc/soc_top_cdc.txt`
+(`grep BAD` it to inspect findings).
+
+## Requirements
+
+- `yosys` >= 0.23 on `PATH` (or fetch oss-cad-suite with `--with-yosys`)
+- `python3`
+- `sv2v` (auto-fetched). Needed because oss-cad-suite's built-in `yosys -sv`
+  reader can't parse this RTL's package-import-in-package, and its `slang`
+  plugin rejects the (frozen) Phase 3 cache RTL's mixed blocking/non-blocking
+  array writes. `sv2v` sidesteps both with zero RTL changes.
+
+## Why it's informational (not a gate yet)
+
+The SoC is currently **single-clock** (`soc_top` fans one `clk_i`/`rst_n_i`
+pair to everything). Because `cdc_snitch` models every top-level input port as a
+separate clock domain, a raw run reports ~5200 `BAD` registers that are **all
+false positives**:
+
+- ~95% are the **async reset** `rst_n_i` modeled as a foreign domain (every flop).
+- the rest are **synchronous** top-level buses (the APB debug bus, SPI) that are
+  actually in the `clk_i` domain.
+- there are **zero genuine internal multi-clock crossings** (correct — one clock).
+
+It *does* correctly recognize the real async input `uart_rx_i` (→ `OKX`, the
+2-FF synchronizer is seen), so it would catch a *missing* synchronizer.
+
+To become a meaningful gate it needs a thin CDC wrapper that neutralizes the
+reset domain and declares the synchronous top-level inputs as `clk_i`-domain.
+That work is deferred to **Phase 6+**, when real multiple clock domains exist
+and the tool earns its keep. See the POC writeup for details.

--- a/tools/cdc/fetch_cdc_tools.sh
+++ b/tools/cdc/fetch_cdc_tools.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Fetch the (pinned) tools used by the CDC check into the cache dir.
+#
+#   - cdc_snitch.py + cdc_snitch_proc.ys  (BerkeleyLab/Bedrock, pinned commit)
+#   - sv2v                                (zachjs/sv2v, pinned release)
+#   - oss-cad-suite (yosys)               (only with --with-yosys)
+#
+# Idempotent: existing files are left in place unless --force is given.
+#
+# Usage:
+#   tools/cdc/fetch_cdc_tools.sh [--with-yosys] [--force]
+#
+# Env:
+#   CDC_CACHE   destination dir (default: <repo>/sim/build/cdc)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/versions.env"
+
+CDC_CACHE="${CDC_CACHE:-$REPO_ROOT/sim/build/cdc}"
+WITH_YOSYS=0
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --with-yosys) WITH_YOSYS=1 ;;
+    --force)      FORCE=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$CDC_CACHE"
+cd "$CDC_CACHE"
+
+fetch() {  # fetch <url> <dest>
+  local url="$1" dest="$2"
+  if [[ -s "$dest" && "$FORCE" -eq 0 ]]; then
+    echo "  [skip] $dest (exists)"
+    return
+  fi
+  echo "  [get ] $dest"
+  curl -fsSL --retry 4 --retry-delay 2 --max-time 600 -o "$dest" "$url"
+}
+
+echo "== cdc_snitch (Bedrock @ ${BEDROCK_SHA:0:12}) =="
+base="https://raw.githubusercontent.com/BerkeleyLab/Bedrock/${BEDROCK_SHA}/build-tools"
+fetch "$base/cdc_snitch.py"      "cdc_snitch.py"
+fetch "$base/cdc_snitch_proc.ys" "cdc_snitch_proc.ys"
+
+echo "== sv2v (${SV2V_VERSION}) =="
+if [[ ! -x "$CDC_CACHE/sv2v-Linux/sv2v" || "$FORCE" -eq 1 ]]; then
+  fetch "https://github.com/zachjs/sv2v/releases/download/${SV2V_VERSION}/sv2v-Linux.zip" "sv2v.zip"
+  unzip -o -q sv2v.zip
+  chmod +x "$CDC_CACHE/sv2v-Linux/sv2v"
+else
+  echo "  [skip] sv2v-Linux/sv2v (exists)"
+fi
+
+if [[ "$WITH_YOSYS" -eq 1 ]]; then
+  echo "== oss-cad-suite (${OSS_CAD_SUITE_TAG}) — ~700 MB =="
+  if [[ ! -x "$CDC_CACHE/oss-cad-suite/bin/yosys" || "$FORCE" -eq 1 ]]; then
+    date="${OSS_CAD_SUITE_TAG//-/}"
+    fetch "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${OSS_CAD_SUITE_TAG}/oss-cad-suite-linux-x64-${date}.tgz" "oss-cad-suite.tgz"
+    tar -xzf oss-cad-suite.tgz
+  else
+    echo "  [skip] oss-cad-suite/bin/yosys (exists)"
+  fi
+fi
+
+echo "done -> $CDC_CACHE"

--- a/tools/cdc/run_cdc.sh
+++ b/tools/cdc/run_cdc.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Run the BerkeleyLab/Bedrock cdc_snitch clock-domain-crossing check on a
+# SystemVerilog design: sv2v -> yosys (flatten to gates) -> cdc_snitch.py.
+#
+# This is an INFORMATIONAL check by default (CDC_STRICT=0): on this single-clock
+# SoC, cdc_snitch reports thousands of false-positive BADs because it models
+# every top-level input port (including the async reset and synchronous APB/SPI
+# buses) as an independent clock domain. See tools/cdc/README.md and
+# docs/verification/CDC_SNITCH_POC.md for the full story.
+#
+# Env (all optional except CDC_FLIST):
+#   CDC_FLIST    newline-separated list of source files (required)
+#   CDC_CACHE    tool/work dir            (default: <repo>/sim/build/cdc)
+#   CDC_INCDIRS  space-separated incdirs  (default: none)
+#   CDC_TOP      top module name          (default: soc_top)
+#   CDC_STRICT   1 = exit non-zero on BAD>0 (gate); 0 = informational (default)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CDC_CACHE="${CDC_CACHE:-$REPO_ROOT/sim/build/cdc}"
+CDC_TOP="${CDC_TOP:-soc_top}"
+CDC_STRICT="${CDC_STRICT:-0}"
+CDC_INCDIRS="${CDC_INCDIRS:-}"
+: "${CDC_FLIST:?set CDC_FLIST to a file listing the RTL sources}"
+
+# Make cached sv2v / oss-cad-suite yosys discoverable without polluting PATH.
+export PATH="$CDC_CACHE/oss-cad-suite/bin:$CDC_CACHE/sv2v-Linux:$PATH"
+
+command -v sv2v   >/dev/null 2>&1 || { echo "ERROR: sv2v not found. Run tools/cdc/fetch_cdc_tools.sh"; exit 3; }
+command -v yosys  >/dev/null 2>&1 || { echo "ERROR: yosys not found. Install yosys>=0.23 or run fetch_cdc_tools.sh --with-yosys"; exit 3; }
+[[ -f "$CDC_CACHE/cdc_snitch.py" ]] || { echo "ERROR: cdc_snitch.py missing. Run tools/cdc/fetch_cdc_tools.sh"; exit 3; }
+
+mkdir -p "$CDC_CACHE"
+INC_FLAGS=()
+for d in $CDC_INCDIRS; do INC_FLAGS+=("-I$d"); done
+
+mapfile -t FILES < <(grep -vE '^\s*(#|$)' "$CDC_FLIST")
+
+echo "== [1/3] sv2v: SystemVerilog -> Verilog-2005 =="
+sv2v "${INC_FLAGS[@]}" "--top=$CDC_TOP" "${FILES[@]}" > "$CDC_CACHE/${CDC_TOP}_flat.v"
+
+echo "== [2/3] yosys: elaborate + flatten -> JSON =="
+yosys -q -p "read_verilog $CDC_CACHE/${CDC_TOP}_flat.v; script $CDC_CACHE/cdc_snitch_proc.ys; write_json $CDC_CACHE/${CDC_TOP}_yosys.json"
+
+echo "== [3/3] cdc_snitch: categorize registers =="
+set +e
+python3 "$CDC_CACHE/cdc_snitch.py" "$CDC_CACHE/${CDC_TOP}_yosys.json" -o "$CDC_CACHE/${CDC_TOP}_cdc.txt"
+rc=$?
+set -e
+echo "report: $CDC_CACHE/${CDC_TOP}_cdc.txt"
+
+if [[ "$CDC_STRICT" -eq 1 ]]; then
+  exit "$rc"
+fi
+echo "NOTE: informational mode (CDC_STRICT=0). On this single-clock SoC the BAD"
+echo "      count is dominated by false positives (async reset + synchronous"
+echo "      APB/SPI ports modeled as separate clock domains). Not a CI gate yet;"
+echo "      see docs/verification/CDC_SNITCH_POC.md."
+exit 0

--- a/tools/cdc/versions.env
+++ b/tools/cdc/versions.env
@@ -1,0 +1,15 @@
+# Pinned tool versions for the CDC (clock-domain-crossing) check.
+# Sourced by fetch_cdc_tools.sh. See tools/cdc/README.md for context.
+
+# BerkeleyLab/Bedrock build-tools/cdc_snitch.{py,proc.ys} — pinned commit.
+BEDROCK_SHA=8929d4defa0201feca62a16af638767a92a9bfa4
+
+# zachjs/sv2v — SystemVerilog -> Verilog-2005 front-end preprocessor.
+# Needed because oss-cad-suite's built-in yosys -sv reader cannot parse this
+# RTL's package-import-in-package, and its slang plugin rejects the (frozen)
+# Phase 3 cache RTL's mixed blocking/non-blocking array writes.
+SV2V_VERSION=v0.0.13
+
+# YosysHQ/oss-cad-suite-build — only fetched when run with --with-yosys.
+# Any reasonably recent yosys (>= 0.23) on PATH works just as well.
+OSS_CAD_SUITE_TAG=2026-06-08


### PR DESCRIPTION
## Summary

Integrate Berkeley Lab's open-source `cdc_snitch` tool as an informational clock-domain-crossing (CDC) static check. The tool is wired up, proven to run on the full `soc_top` RTL, but **parked as informational** — not a CI gate — because the current single-clock SoC produces ~5200 false-positive `BAD` registers (95% from async reset modeled as a separate domain).

## Key Changes

- **`tools/cdc/`** — New CDC tooling directory:
  - `fetch_cdc_tools.sh`: Idempotent fetcher for pinned `cdc_snitch.py`, `sv2v`, and optional `oss-cad-suite` (yosys)
  - `run_cdc.sh`: Main runner (sv2v → yosys flatten → cdc_snitch.py analysis)
  - `versions.env`: Pinned tool versions (Bedrock commit `8929d4d`, sv2v v0.0.13, oss-cad-suite 2026-06-08)
  - `README.md`: Usage guide and explanation of why it's informational

- **`sim/Makefile`** — New `cdc` target:
  - `make cdc` — runs the check informational (exit 0 always)
  - `make cdc CDC_STRICT=1` — gate semantics (exit non-zero if `BAD > 0`)
  - Automatically fetches tools and builds file list from `SOC_TOP_SOURCES`

- **`docs/verification/CDC_SNITCH_POC.md`** — Full feasibility POC writeup:
  - Explains what `cdc_snitch` does and its register classification scheme
  - Documents the toolchain (sv2v needed because oss-cad-suite's yosys can't parse package-import-in-package; slang plugin rejects Phase 3 cache RTL's mixed blocking/non-blocking array writes)
  - Reports results: 18249 `OK1`, 0 `CDC`, 8653 `OKX`, 5234 `BAD` (all false positives on single-clock SoC)
  - Correctly identifies real async input `uart_rx_i` (→ `OKX`, 2-FF synchronizer seen)
  - Defers gate implementation to Phase 6+ when real multi-clock domains exist

- **`docs/verification/VERIFICATION_PLAN.md`** — Updated RTL verification table:
  - Added CDC check row with reference to `make cdc` and POC writeup

## Implementation Details

- **sv2v preprocessing required**: oss-cad-suite's built-in `yosys -sv` reader fails on this RTL's package-import-in-package (`soc_addr_map_pkg.sv`); its `slang` plugin rejects the frozen Phase 3 cache RTL's mixed blocking/non-blocking writes to `valid_array`/`dirty_array`. sv2v sidesteps both with zero RTL changes.

- **False positives on single-clock SoC**: ~95% of `BAD` registers are the async reset `rst_n_i` (modeled as a separate clock domain by cdc_snitch). The remaining ~5% are synchronous top-level buses (APB debug, SPI) that are actually in the `clk_i` domain. Zero genuine internal multi-clock crossings exist (correct — one clock).

- **To become a real gate (Phase 6+)**: Needs a thin CDC wrapper that (1) neutralizes the async-reset domain, (2) declares synchronous top-level inputs as `clk_i`-domain, (3) marks intentional crossings with `magic_cdc` attribute. Then `BAD=0` can gate CI.

- **One hardening opportunity identified**: `u_spi.rx_shift_q` / `rx_push_data` samples `spi_miso_i` without a 2-FF synchronizer (harmless in master mode but worth tracking as a beads issue for CDC hyg

https://claude.ai/code/session_017sczQgj5ofS9wsB4HHqwoj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clock-domain-crossing (CDC) verification capability to detect potential CDC violations in hardware designs.
  * Introduced a new `make cdc` command for running CDC checks.

* **Documentation**
  * Added comprehensive CDC verification guide and tool documentation.
  * Updated verification plan to include CDC checks as an informational test category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->