### PR TITLE
[Fix] Declare signals before use in rv32i_core and rv32i_cpu_top

### DIFF
--- a/rtl/cpu/core/rv32i_core.sv
+++ b/rtl/cpu/core/rv32i_core.sv
@@ -265,7 +265,8 @@ module rv32i_core #(
 
     // Placed after the EX1* register declarations it reads (declare-before-use,
     // IEEE 1800 §6.21 — strict elaborators like slang reject a forward reference).
-    assign dbg_halted = dbg_halted_wb && !id_ex_reg.valid && !ex1a_ex1b_reg_q.valid && !ex1c_ex1b_reg_q.valid && !ex1b_ex2_reg_q.valid && !ex_mem_reg.valid;
+    assign dbg_halted = dbg_halted_wb && !id_ex_reg.valid && !ex1a_ex1b_reg_q.valid &&
+                        !ex1c_ex1b_reg_q.valid && !ex1b_ex2_reg_q.valid && !ex_mem_reg.valid;
 
     always_ff @(posedge clk) begin
         if (!rst_n || flush_ex1a_ex1b)

--- a/rtl/cpu/core/rv32i_core.sv
+++ b/rtl/cpu/core/rv32i_core.sv
@@ -244,7 +244,6 @@ module rv32i_core #(
     logic        dbg_ebreak_from_ex;
 
     assign dbg_halt_combined = dbg_halt_req || dbg_ebreak_from_ex;
-    assign dbg_halted = dbg_halted_wb && !id_ex_reg.valid && !ex1a_ex1b_reg_q.valid && !ex1c_ex1b_reg_q.valid && !ex1b_ex2_reg_q.valid && !ex_mem_reg.valid;
 
     logic [31:0] pc_if_out;
 
@@ -263,6 +262,10 @@ module rv32i_core #(
     ex1a_ex1b_t ex1c_ex1b_reg_q;   // registered EX1c output — fed into u_ex1b
     ex1_ex2_reg_t ex1b_comb;       // combinational output from u_ex1b (EX1b)
     ex1_ex2_reg_t ex1b_ex2_reg_q;  // registered EX1b output — fed into u_ex2 (Run-23)
+
+    // Placed after the EX1* register declarations it reads (declare-before-use,
+    // IEEE 1800 §6.21 — strict elaborators like slang reject a forward reference).
+    assign dbg_halted = dbg_halted_wb && !id_ex_reg.valid && !ex1a_ex1b_reg_q.valid && !ex1c_ex1b_reg_q.valid && !ex1b_ex2_reg_q.valid && !ex_mem_reg.valid;
 
     always_ff @(posedge clk) begin
         if (!rst_n || flush_ex1a_ex1b)

--- a/rtl/cpu/rv32i_cpu_top.sv
+++ b/rtl/cpu/rv32i_cpu_top.sv
@@ -252,6 +252,11 @@ module rv32i_cpu_top #(
                          (apb_paddr_i >= 12'h200) && (apb_paddr_i <= 12'h214) &&
                          (apb_paddr_i[1:0] == 2'b00);
 
+  // DBG_INSTR latch: holds the last retired instruction (commit or trap) so
+  // the register reads non-zero when the CPU is halted and the pipeline is empty.
+  // Declared ahead of the APB read mux that reads it (declare-before-use).
+  logic [31:0] last_commit_insn_q;
+
   // APB read logic
   always_comb begin
     apb_prdata_o = 32'h0;
@@ -318,9 +323,6 @@ module rv32i_cpu_top #(
 
   // Edge detection for dbg_halted (to auto-clear command bits)
   logic dbg_halted_prev;
-  // DBG_INSTR latch: holds the last retired instruction (commit or trap) so
-  // the register reads non-zero when the CPU is halted and the pipeline is empty.
-  logic [31:0] last_commit_insn_q;
 
   always_ff @(posedge clk_i) begin
     if (!rst_n_i)


### PR DESCRIPTION
Fixes #111

## Problem

Strict LRM elaborators (slang/pyslang, used by hdl-schemview's `svxprobe-elaborate`) reject forward references that Verilator tolerates — 4 "identifier used before its declaration" errors:

- `rtl/cpu/core/rv32i_core.sv:247` — the `dbg_halted` pipeline-empty assign reads `ex1a_ex1b_reg_q` / `ex1c_ex1b_reg_q` / `ex1b_ex2_reg_q`, declared ~15 lines later.
- `rtl/cpu/rv32i_cpu_top.sv:272` — the APB read mux reads `last_commit_insn_q`, declared ~50 lines later.

Beyond the diagnostics, the affected expressions lost their connectivity in the extracted schematic model: before this change the model had **no driver for `dbg_halted` at all**.

## Change

Declaration reorder only — zero logic change:

- `rv32i_core.sv`: moved the `assign dbg_halted = ...` below the EX1* pipeline-register declarations it reads.
- `rv32i_cpu_top.sv`: hoisted the `last_commit_insn_q` declaration (with its comment) above the APB read mux; its `always_ff` stays in place.

## Verification

- `svxprobe-elaborate --top soc_top -f soc_top.f`: **zero diagnostics** (was 4 errors), 6257 nodes / 54 files, schema validation clean.
- Model connectivity restored: the `dbg_halted` driver assign now exists with all 6 inputs (`dbg_halted_wb`, `id_ex_reg`, `ex1a_ex1b_reg_q`, `ex1c_ex1b_reg_q`, `ex1b_ex2_reg_q`, `ex_mem_reg`).
- Verilator is not installed in this environment, so `make lint_soc` / cocotb regressions were not run here — recommend a CI pass before merge. Declaration order has no simulation semantics for these constructs, so no behavioral change is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkSK6yBgCpjMBQa8cfMTQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkSK6yBgCpjMBQa8cfMTQG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware build compatibility by adjusting signal declaration order to satisfy stricter elaboration rules.
  * Prevented invalid reference ordering in CPU read logic, helping ensure the design compiles consistently across toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->