### PR TITLE
[Fix] Update stale SOC_SV_FILES in pnr Makefile for Phase-7 APB/PLL refactor

### DIFF
--- a/pnr/Makefile
+++ b/pnr/Makefile
@@ -792,12 +792,17 @@ SOC_SV_FILES := \
 	$(LIBRELANE_ASAP7_SOC_DIR)/gpu_top_stub.sv \
 	$(PROJECT_ROOT)/rtl/soc/pll/pll_clkgen_stub.sv \
 	$(LIBRELANE_ASAP7_SOC_DIR)/pll_clkgen_pnr.sv \
-	$(PROJECT_ROOT)/rtl/soc/pll/pll_axil_regs.sv \
+	$(PROJECT_ROOT)/rtl/soc/pll/pll_apb_regs.sv \
+	$(PROJECT_ROOT)/rtl/soc/pll/pll_subsystem.sv \
 	$(PROJECT_ROOT)/rtl/soc/axi4_crossbar.sv \
 	$(PROJECT_ROOT)/rtl/soc/axi_lite_register_bank.sv \
+	$(PROJECT_ROOT)/rtl/soc/apb4_register_bank.sv \
 	$(PROJECT_ROOT)/rtl/soc/axi_lite_interconnect.sv \
 	$(PROJECT_ROOT)/rtl/soc/axi4_to_axilite.sv \
 	$(PROJECT_ROOT)/rtl/soc/axilite_to_axi4.sv \
+	$(PROJECT_ROOT)/rtl/soc/axil_to_apb.sv \
+	$(PROJECT_ROOT)/rtl/soc/apb_interconnect.sv \
+	$(PROJECT_ROOT)/rtl/soc/soc_bus.sv \
 	$(PROJECT_ROOT)/rtl/soc/sram_controller.sv \
 	$(PROJECT_ROOT)/rtl/soc/boot_rom.sv \
 	$(PROJECT_ROOT)/rtl/periph/dma_engine.sv \


### PR DESCRIPTION
Fixes #112

## Problem

`SOC_SV_FILES` (the `asap7-soc-sv2v` input list in `pnr/Makefile`) went stale when the PLL register bank moved from AXI-Lite to APB and the bus glue was refactored into `soc_bus`:

- it references `rtl/soc/pll/pll_axil_regs.sv`, which **no longer exists** (renamed to `pll_apb_regs.sv`) — sv2v fails on the missing input;
- it's missing the modules `soc_top` now instantiates: `soc_bus.sv`, `pll_subsystem.sv`, plus the APB glue they need (`axil_to_apb.sv`, `apb_interconnect.sv`, `apb4_register_bank.sv` — the latter now instantiated by every peripheral).

## Change

One block in `pnr/Makefile`: replaced the stale `pll_axil_regs.sv` line with `pll_apb_regs.sv` and added the 5 missing files. No target/flow logic changed.

## Verification

sv2v is not installed in this environment, so as a proxy the exact fixed file set (including the PnR stubs `rv32i_cpu_top_stub.sv` / `gpu_top_stub.sv` / `pll_clkgen_pnr.sv`) was elaborated with slang, top `soc_top`: every listed path exists and **all module references resolve** (previously `soc_bus` / `pll_subsystem` / APB modules were unresolvable). Remaining slang diagnostics are pre-existing characteristics of the stub flow that sv2v tolerates (missing `` `timescale `` in some files, and the intentional `PLL_IMPL` string→int mismatch on the PnR `pll_clkgen`, which sv2v erases by converting to untyped Verilog-2005 parameters). Recommend re-running `make asap7-soc-sv2v` where the nix toolchain is available to confirm `soc_top_sv2v.v` regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkSK6yBgCpjMBQa8cfMTQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkSK6yBgCpjMBQa8cfMTQG)_