### PR TITLE
[Doc] Add coding practices guidelines + compliance audit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig — https://editorconfig.org
+# Single source of truth for whitespace/EOL conventions
+# (see docs/development/CODING_GUIDELINES.md).
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# SystemVerilog / Verilog: 4-space house style (.rules.verible_lint)
+[*.{sv,svh,v,vh}]
+indent_size = 4
+
+# Python: ruff format, 4-space (pyproject.toml)
+[*.py]
+indent_size = 4
+
+# Make requires tabs in recipes
+[{Makefile,makefile,*.mk}]
+indent_style = tab
+
+# YAML conventionally 2-space
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown: trailing double-space is a hard line break
+[*.md]
+trim_trailing_whitespace = false

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E501, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         types: [python]
         files: ^tb/(models|tests)/
         args:
-          - --rcfile=pyproject.toml
+          - --rcfile=.pylintrc
           - --fail-under=9.5
 
       # Pytest - Run tests on push only (not on every commit)

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,6 +5,12 @@ fail-under=9.5
 # Use multiple processes to speed up Pylint.
 jobs=0
 
+# Skip frozen legacy test code (mirrors ruff/mypy excludes).
+ignore=legacy
+
+# Discover and analyse Python files in subdirectories.
+recursive=yes
+
 [MESSAGES CONTROL]
 # Disable specific warnings that are acceptable for this project
 disable=
@@ -20,7 +26,26 @@ disable=
     # Duplicate code in immediate value decoding (minor, could extract later)
     duplicate-code,
     # Attributes defined in reset() method is an acceptable pattern
-    attribute-defined-outside-init
+    attribute-defined-outside-init,
+    # line-too-long / import order handled by ruff
+    line-too-long,
+    wrong-import-order,
+    # too-many-lines acceptable for test files
+    too-many-lines,
+    # wrong-import-position intentional for cocotb sys.path setup
+    wrong-import-position,
+    # unnecessary-pass needed for empty template methods
+    unnecessary-pass,
+    # protected-access acceptable in test code
+    protected-access,
+    # unused-argument needed for API compatibility
+    unused-argument,
+    # broad-exception-caught intentional for test robustness
+    broad-exception-caught,
+    # stylistic preferences
+    too-many-return-statements,
+    no-else-return,
+    consider-using-in
 
 [FORMAT]
 # Maximum number of characters on a single line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,11 @@ See each phase in `docs/verification/VERIFICATION_PLAN.md` for detailed AI/Human
 
 Use the format: `[Category] Brief description`
 
-Categories: `[Fix]`, `[Feature]`, `[Code]` (refactoring), `[Env]` (build), `[Doc]`, `[Test]`, `[Spec]`.
+Categories: `[Fix]`, `[Feature]`, `[Code]` (refactoring), `[Env]` (build), `[Doc]`, `[Test]`, `[Spec]`, `[RTL]` (RTL design), `[PD]` (physical design), `[Analog]` (mixed-signal), `[Chore]` (maintenance).
+
+## Coding Guidelines
+
+All new/modified code follows [`docs/development/CODING_GUIDELINES.md`](docs/development/CODING_GUIDELINES.md) (SystemVerilog per lowRISC-adapted house style, Python per ruff/PEP 8). Compliance backlog: [`docs/development/CODING_COMPLIANCE_AUDIT.md`](docs/development/CODING_COMPLIANCE_AUDIT.md). Existing verified RTL is grandfathered — no style-only mass edits.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Core specifications in `docs/`:
 | `design/MEMORY_MAP.md` | Address space and register map |
 | `design/REFERENCE_MODEL_SPEC.md` | Python reference model API |
 | `verification/VERIFICATION_PLAN.md` | Verification strategy by phase |
+| `development/CODING_GUIDELINES.md` | Coding practices & style guidelines (RTL + Python + shell) |
+| `development/CODING_COMPLIANCE_AUDIT.md` | Guidelines compliance audit and remediation backlog |
 
 README detail set in `docs/readme/`:
 

--- a/docs/development/CODING_COMPLIANCE_AUDIT.md
+++ b/docs/development/CODING_COMPLIANCE_AUDIT.md
@@ -1,0 +1,115 @@
+# Coding Guidelines Compliance Audit
+
+**Date**: 2026-07-07 · **Baseline**: `e8e633d` (post-PR #113)
+**Guidelines**: [`CODING_GUIDELINES.md`](CODING_GUIDELINES.md)
+
+Audit of the current codebase against the adopted guidelines. Corpus: 63 `.sv` files
+under `rtl/` (the 11 `.v` files in the tree are vendor stubs/sim models, out of scope),
+~207 Python files (~55 k lines, of which ~17 k are the stale `micro_p/` duplicate).
+
+Per the adopted policy, existing verified code is **grandfathered** — the violations
+below are a prioritized backlog, not a mandate for immediate mass edits.
+
+---
+
+## 1. What already complies (codified as-is)
+
+| Area | Finding |
+| :--- | :--- |
+| RTL file organization | One module per file, filename == module name: **100 %** of `rtl/` files. All 6 packages follow `*_pkg.sv` with no co-located modules. |
+| RTL processes | `always_ff`/`always_comb` only — **zero** plain `always @` blocks in `rtl/`. |
+| Reset polarity | Uniformly active-low `rst_n` — no active-high resets anywhere. |
+| Ports | ANSI style, one per line, clk/rst first, interface-grouped with banner comments. |
+| Case discipline | No `casex`; the 4 `casez` sites are `unique casez` don't-care decodes (e.g. `rtl/periph/uart_controller.sv:190`). |
+| Constants | `localparam` vs `parameter` used correctly; params `ALL_CAPS`. |
+| Types | Strong package/typedef/enum/struct usage; enums packed with explicit base types (`rtl/gpu/gpu_pkg.sv:38`). |
+| Whitespace | Spaces only — no tabs in `rtl/` or Python. |
+| Python core | `tb/models`, `tb/tests`, `sim`, `sw` are ruff-format-clean, typed (PEP 604), Google-docstring'd, pylint ≥ 9.5. |
+| Python safety | No wildcard imports, no bare `except:` anywhere. |
+| Shell | `install-missing-tools/`, `tools/cdc/`, plugin wrappers all use `set -euo pipefail`. |
+| Declaration before use | `rv32i_core.sv` / `rv32i_cpu_top.sv` violations fixed in PR #113 (issue #111). |
+
+---
+
+## 2. Violations and remediation plan
+
+Priorities: **P1** = low-risk, high-value, do soon · **P2** = mechanical cleanup,
+schedule freely · **P3** = touches verified RTL semantics/interfaces, needs full
+regression (`soc_all` 73/73) and its own review; naming-only changes don't invalidate
+ASAP7 sign-off but a confirmation P&R run is prudent.
+
+### P1 — low-risk, high-value
+
+| # | Finding | Evidence | Proposal |
+| :- | :--- | :--- | :--- |
+| P1-1 | No license ⇒ no SPDX headers possible. 0 of 63 RTL files (and no Python file) carry a license header; no `LICENSE` file exists (README says "educational and testing purposes"). | `grep -rl 'SPDX\|Copyright' rtl` → 0 | Choose a license (MIT/Apache-2.0 typical for educational HW), add `LICENSE`, then add SPDX tags file-by-file as files are touched. |
+| P1-2 | Stale `micro_p/` tree: ~17,421 Python lines (~31 % of all Python) duplicating an old `tb/` + `sim/` snapshot; unreferenced by pyproject, testpaths, or CI. | `diff -rq tb micro_p/tb` shows dozens of divergent copies | Delete `micro_p/` (git history preserves Phase 1). If it must stay, add a top-level `micro_p/README.md` marking it frozen and exclude it in every tool config. |
+| P1-3 | `sim/cxx_shim.sh` has no `set -e` — a compiler shim that silently continues past failures. | only `.sh` in tree without it | Add `set -euo pipefail`. |
+| P1-4 | RTL CI is non-gating: `rtl-checks.yml` runs Verible with `continue-on-error: true`; ~33 open findings (`case-missing-default`, `always-ff-non-blocking`) per `.rules.verible_lint` note. | `.github/workflows/rtl-checks.yml`; `.rules.verible_lint:45` | Burn down the ~33 findings (each is a real latch/discipline risk), then drop `continue-on-error` to make Verible a hard gate. |
+| P1-5 | Python CI gate covers only `tb/models tb/tests` — `tb/cpu_uvm`, `sim`, `tb/cocotb`, `pnr`, `analog`, `plugins` have zero CI lint/type enforcement. Pre-commit covers more (`tb/cpu_uvm`, `sim`) than CI, so local and CI results diverge. | `qa-checks.yml` hardcodes the two dirs in every step | Step 1: align CI scope with pre-commit (`tb/models tb/tests tb/cpu_uvm sim`). Step 2: ruff-format `tb/cocotb` (P2-2) then add it. |
+| P1-6 | Hardcoded machine-specific absolute paths break portability. | `analog/pll_clkgen/sky130/sim/run_vco_sweep.py:10-11` (`/home/neuromorphic/...`), also `run_vco_sweep_retuned.py` | Derive repo root from `__file__`; take the librelane path from an env var with a documented default. |
+| P1-7 | Verilator lint (`make lint` / `lint_soc`) exists but is not run in any CI workflow. | `sim/Makefile:339`; no workflow invokes it | Add a Verilator lint job to `rtl-checks.yml` (blocking — the tree is already clean). |
+
+### P2 — mechanical cleanup
+
+| # | Finding | Evidence | Proposal |
+| :- | :--- | :--- | :--- |
+| P2-1 | Indent outliers vs 4-space rule: `rtl/cpu/core/rv32i_alu.sv` is 2-space throughout (36 two-space vs 2 four-space top-level indents); `rtl/cpu/rv32i_cpu_top.sv` mixes 2-space ports with 4-space body (210 vs 93). | verified by count | `make format-verible-fix VERIBLE_CHECK_FILES="rtl/cpu/core/rv32i_alu.sv rtl/cpu/rv32i_cpu_top.sv"`; formatting-only diff, sim-verify with existing regressions. |
+| P2-2 | `tb/cocotb` (live dirs) is not ruff-formatted: 181 lines > 100 cols, hand-aligned assignment columns, `#`-comment headers instead of module docstrings, third-party-before-stdlib import order. | `tb/cocotb/soc/test_timer.py:1-38` | Run `ruff format` + `ruff check --fix` over `tb/cocotb` (excluding `legacy/`), convert headers to docstrings, then add to pre-commit + CI scope. |
+| P2-3 | Comma-joined imports (E401) in ungoverned scripts. | `analog/.../run_vco_sweep.py:8`, `analog/.../budget_pll_sky130.py:9`, `pnr/asap7/soc/gen_soc_top_hjson.py:31`, `pnr/freepdk45/gen_via_stubs.py:15` | One import per line; bring `pnr/`/`analog/`/`plugins/` under ruff (add to CI scope once clean). |
+| P2-4 | Misleading dead `sys.path` hack: insert placed *after* the import it would enable. | `tb/tests/test_rv32i_model.py:12-15` | Reorder or delete the insert. |
+| P2-5 | Inline-pragma waiver sprawl instead of scoped waivers: e.g. 11 `lint_off UNUSEDPARAM` pairs in `rtl/gpu/gpu_pkg.sv:4-33`. | grep `verilator lint_off` | Consolidate per-file waivers to a commented block at file top (or a central `.vlt` waiver file) with reasons. |
+| P2-6 | No shellcheck anywhere; `pnr/constraints/validate_sdc.sh` uses `#!/bin/bash` instead of `#!/usr/bin/env bash`. | — | Add a shellcheck pre-commit hook (new scripts blocking, existing advisory); fix the shebang. |
+| P2-7 | Test-quality gaps: ~86 % of asserts have no message (51 asserts, 1 message in `tb/tests/test_rv32i_model.py`); no `conftest.py`/fixtures — every test constructs `RV32IModel()` inline. | `tb/tests/test_rv32i_model.py:23,43,54,69` | Add a `cpu` fixture in `tb/tests/conftest.py`; add messages to non-obvious asserts opportunistically. |
+| P2-8 | Docstring style mixed: NumPy-style underline sections inside an otherwise Google-style package. | `tb/models/cache_model.py:50-55` | Convert to Google style when next touched. |
+
+### P3 — refactors requiring re-verification (proposal only)
+
+These change signal/port names or semantics in signed-off RTL. Each item = its own
+branch + full regression (`soc_all` 73/73, CPU rollup, GPU suite) + prudence P&R re-run.
+
+| # | Finding | Evidence | Proposal |
+| :- | :--- | :--- | :--- |
+| P3-1 | Port-suffix split: GPU + CPU-top fully `_i`/`_o`; CPU leaf modules bare (`rtl/cpu/core/rv32i_alu.sv:20-30`: `operand_a`, `result`); periph mixed within single modules (`rtl/periph/uart_controller.sv:54-75`: bare `psel`/`prdata` beside `uart_tx_o`). | ~40 files suffixed, ~30 not | Harmonize to `_i`/`_o` per guidelines, one subsystem per change, starting with periph (smallest). |
+| P3-2 | Clock/reset naming split: `clk_i`/`rst_n_i` in only 8 files (CPU top/core, soc_top, PLL); bare `clk`/`rst_n` in 36 — inconsistent even inside the CPU. | grep counts | Rename toward `clk_i`/`rst_n_i` together with P3-1 per subsystem. |
+| P3-3 | Register-suffix drift: `_q` dominates (~1,930 uses) but `_r` used in `rtl/cpu/core/rv32i_core.sv`, `rtl/mem/rv32i_icache.sv`, `rtl/cpu/core/pipeline/rv32i_pipeline_ex1c.sv`; `_next` (7) coexists with `_d` (52). | grep | Rename `_r`→`_q`, `_next`→`_d` (mechanical, sim-verified). |
+| P3-4 | File-scope package imports in 13 files (all cpu/mem): `rtl/cpu/core/rv32i_core.sv:13-15`, `rtl/mem/rv32i_dcache.sv:36-38`, all pipeline stages, `rtl/cpu/rv32i_cpu_top.sv:5`. GPU/soc/periph already use module-scoped imports. | `grep -rl '^import ' rtl` → 13 | Move to `module x import pkg::*;` header form. Note: `lint_soc` currently waives `-Wno-IMPORTSTAR`; after this fix the waiver can go. |
+| P3-5 | `wire` declarations instead of `logic`: `rtl/periph/uart_controller.sv:182-250`, `rtl/periph/spi_controller.sv:170-237`, `rtl/gpu/vector_register_file.sv:42-44`. | grep | `wire x = expr;` → `logic x; assign x = expr;` (or keep single-line `logic` continuous assigns), per file, sim-verified. |
+| P3-6 | Reset-discipline split: GPU + soc bridges async (`rtl/gpu/warp_scheduler.sv:142`), CPU pipeline + periph sync (`rtl/periph/timer.sv`) — documented as intentional (`sim/Makefile` `SYNCASYNCNET` waiver note) but heterogeneous. | — | **Recommend: accept as documented.** New modules follow the async-assert/sync-deassert guideline; unifying frozen leaf RTL is high-risk for zero functional gain. Revisit only at a tape-out gate. |
+| P3-7 | Declaration-before-use: two known violators fixed (PR #113); rest of tree unswept. | — | Sweep remaining 61 files (Verible `forbid-forward-references`-style manual/scripted check); fix any stragglers found. |
+
+### Config/tooling contradictions — **fixed in this change**
+
+| Finding | Resolution applied |
+| :--- | :--- |
+| `.flake8` disabled E501/W503, contradicting ruff's 100-col limit; flake8 wired into nothing (not CI, not pre-commit). | **Deleted `.flake8`.** Ruff is the lint authority. |
+| Two competing pylint configs: `.pylintrc` (fail-under 9.5, design limits) vs `pyproject.toml [tool.pylint]` (different disable list). Bare `pylint` (CI) read `.pylintrc`; pre-commit read pyproject — different rules per invocation. | **Merged pyproject's `[tool.pylint]` into `.pylintrc`** (single source); pre-commit hook now points at `.pylintrc`. |
+| No `.editorconfig` despite a documented 4-space rule. | **Added `.editorconfig`.** |
+| Commit categories drifted: `[RTL]` (9), `[Chore]` (8), `[Analog]` (7), `[PD]` (4) in active use but undocumented; `[Spec]` documented but unused. | **CLAUDE.md category list expanded** to match reality. |
+| Guidelines not discoverable. | **Linked from README + CLAUDE.md.** |
+
+---
+
+## 3. Per-subsystem consistency matrix (reference)
+
+| Dimension | CPU leaf (alu/regfile) | CPU top/core | GPU | periph | soc |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Port `_i/_o` | none | yes | yes (all) | partial | partial |
+| clk/rst naming | `clk`/`rst_n` | `clk_i`/`rst_n_i` | `clk`/`rst_n` | `clk`/`rst_n` | mixed |
+| Reset discipline | sync | sync (pipeline) / async (control) | async | sync | mixed |
+| `logic` vs `wire` | logic | logic | mostly logic | wire-heavy | logic |
+| Indent | 2-space (alu) | mixed 2/4 (top) | 4-space | 4-space | 4-space |
+| `default_nettype none` | no | no | yes | yes | mostly |
+| pkg import placement | file-scope | file-scope | module header | module header | module header |
+
+## 4. Suggested sequencing
+
+1. **Now (this change)**: config fixes above (done).
+2. **Next session**: P1-3 (`cxx_shim.sh`, verify sim builds still pass), P1-2
+   (`micro_p/` deletion), P1-4 (Verible burn-down → hard gate), P1-5 step 1 (CI scope),
+   P1-7 (Verilator in CI).
+3. **Then**: P2 batch (formatting-only diffs, cheap to review).
+4. **Scheduled refactors**: P3-3/P3-4/P3-5 (mechanical, sim-verified), then P3-1/P3-2
+   per subsystem. P3-6 accepted as-is.
+
+File each as a `bd` issue when picked up.

--- a/docs/development/CODING_GUIDELINES.md
+++ b/docs/development/CODING_GUIDELINES.md
@@ -1,0 +1,218 @@
+# Coding Practices & Style Guidelines
+
+**Status**: Adopted 2026-07-07 · **Applies to**: all new and modified code
+**Compliance audit**: [`CODING_COMPLIANCE_AUDIT.md`](CODING_COMPLIANCE_AUDIT.md)
+
+This document consolidates the project's coding standards for SystemVerilog RTL, Python,
+and shell/build scripts. It is based on industry references — the
+[lowRISC Verilog Style Guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md)
+for RTL and [PEP 8](https://peps.python.org/pep-0008/) (enforced via ruff) for Python —
+adapted where the established house style deliberately deviates. Where a rule is already
+enforced by a tool config, this document points at the config rather than restating it;
+**the config file is authoritative**.
+
+## Scope and enforcement policy
+
+- **New code and modified code MUST comply.** When you touch a module or script, bring
+  the lines you touch into compliance; whole-file cleanup is encouraged but not required.
+- **Existing verified code is grandfathered.** Signed-off RTL (ASAP7/Sky130 PPA runs,
+  `soc_all` 73/73 regression) is not retro-edited for style alone. Deviations are
+  tracked as a prioritized backlog in the [compliance audit](CODING_COMPLIANCE_AUDIT.md);
+  each cleanup lands as its own reviewed change with regression evidence.
+- Authoritative tool configs: `.rules.verible_lint` (RTL style-lint),
+  `sim/Makefile` `VERIBLE_FMT_FLAGS` (RTL formatting), `pyproject.toml` (ruff/mypy/pytest),
+  `.pylintrc` (pylint), `.pre-commit-config.yaml` (local gates), `.editorconfig` (whitespace).
+
+---
+
+## 1. SystemVerilog RTL
+
+Reference: lowRISC Verilog Style Guide, adapted to the house style codified in
+`.rules.verible_lint` and the Verible formatter flags in `sim/Makefile`.
+
+### 1.1 File organization
+
+| Rule | Detail |
+| :--- | :--- |
+| One module per file | Exactly one `module` (or one `package`) per `.sv` file. |
+| Filename == module name | `rv32i_alu.sv` contains `module rv32i_alu`. Verible `module-filename` enforces this. |
+| Package files | One `package` per file, **no modules in the same file**, filename `<pkg_name>.sv` matching the package name, with the `_pkg` suffix (`gpu_pkg.sv` → `package gpu_pkg`). |
+| File header | Every file opens with a `//` comment block: module purpose, key behaviors, protocol notes. See `rtl/periph/uart_controller.sv:1` for the exemplar. |
+| License header | Once the project adopts a formal license (see audit P1-1), every new file carries an SPDX tag (`// SPDX-License-Identifier: <license>`) under the header. |
+
+### 1.2 Naming
+
+| Item | Convention | Example |
+| :--- | :--- | :--- |
+| Modules | `snake_case`, subsystem prefix | `rv32i_alu`, `gpu_compute_unit` |
+| Signals | `snake_case` | `mem_rdata`, `warp_active` |
+| Parameters / localparams | `ALL_CAPS` (documented deviation from lowRISC CamelCase; `parameter-name-style` disabled in `.rules.verible_lint`) | `AXI_ADDR_WIDTH`, `N_MASTERS` |
+| Registered signals | `_q` suffix | `state_q` |
+| Combinational next-state | `_d` suffix (`_w` acceptable for derived combinational nets per `.rules.verible_lint`; do **not** use `_r` or `_next` in new code) | `state_d` |
+| Input ports | `_i` suffix | `opcode_i` |
+| Output ports | `_o` suffix | `result_o` |
+| Bidirectional ports | `_io` suffix | `pad_io` |
+| Clock | `clk_i` (additional clocks `clk_<name>_i`) | `clk_i` |
+| Reset | `rst_n_i` — active-low is **mandatory**; no active-high resets | `rst_n_i` |
+| Enums / types | `snake_case` with `_e` / `_t` suffix, packed with explicit base type | `typedef enum logic [6:0] {...} gpu_opcode_e` |
+
+### 1.3 Language constructs
+
+- **`logic` only.** No `reg`; no `wire` for new declarations (continuous assigns drive
+  `logic` fine). `` `default_nettype none `` at the top of each file (restore with
+  `` `default_nettype wire `` at the end) to catch implicit nets.
+- **`always_ff` / `always_comb` only.** Never plain `always @(...)`. Sequential blocks
+  use non-blocking (`<=`); combinational blocks use blocking (`=`). Never mix within a block.
+- **Case statements**: `unique case` with a `default` arm. `casez` only for genuine
+  don't-care matching (byte strobes, priority encoders), always `unique casez`.
+  **`casex` is banned.**
+- **Constants**: `localparam` for module-internal constants; `parameter` only for values
+  a parent may override.
+- **Declaration before use**: every signal, typedef, and localparam MUST be declared
+  textually before its first reference within the module. No forward references
+  (see fix #111 / PR #113 for prior violations).
+- **Package imports are module-scoped**: `module foo import gpu_pkg::*; (...)`.
+  File-scope `import pkg::*;` above the module is **banned** in new code — it pollutes
+  the compilation unit and breaks tool-ordering assumptions.
+- **Latches are banned.** All combinational outputs assigned on every path
+  (Verilator lint + `case-missing-default` guard this).
+
+### 1.4 Reset style
+
+- **New modules**: asynchronous assertion, synchronous deassertion, active-low —
+  `always_ff @(posedge clk_i or negedge rst_n_i)` with an external reset synchronizer
+  per clock domain (lowRISC standard; already the GPU / SoC-bridge discipline).
+- **Grandfathered**: the CPU core/pipeline and peripherals use fully synchronous reset —
+  a documented, intentional legacy discipline (see the `SYNCASYNCNET` waiver note in
+  `sim/Makefile` `lint_soc`). Do not flip verified resets for style alone; any
+  unification is a P3 audit item requiring full regression.
+- Within one subsystem, the discipline must be uniform.
+
+### 1.5 Ports and module headers
+
+- ANSI-style port declarations only; one port per line; direction-aligned.
+- Order: `clk_i`, `rst_n_i` first, then ports grouped by interface with banner comments
+  (see `rtl/periph/timer.sv` port list).
+- Parameter list `#(...)` precedes the port list; explicit named port connections
+  (`.a(b)`) at instantiation sites — no positional connections.
+
+### 1.6 Formatting
+
+- **4-space indent, spaces only, no tabs** (`.editorconfig` + Verible `no-tabs`).
+- Line length: soft limit 120 columns (`--column_limit=120`); hand-aligned AXI port maps
+  may exceed it (`line-length` rule intentionally disabled).
+- `begin`/`end` K&R style (`begin` trails the statement).
+- Canonical formatting = `make format-verible-check` / `make format-verible-fix`
+  (`sim/Makefile` `VERIBLE_FMT_FLAGS` is the authority).
+
+### 1.7 Lint gates
+
+Before committing RTL:
+
+```bash
+cd sim
+make lint        # Verilator semantic lint (CPU top)
+make lint_soc    # Verilator semantic lint (SoC top)
+make verible     # Verible style lint + format check
+```
+
+- Prefer fixing findings over waiving. If a waiver is genuinely needed, prefer a
+  scoped, commented waiver near the top of the file over scattering inline
+  `lint_off`/`lint_on` pairs through the body; every waiver carries a one-line reason.
+- CI runs Verible via `.github/workflows/rtl-checks.yml` (currently non-blocking during
+  adoption; the goal is a hard gate once the open findings are burned down — audit P1-4).
+
+---
+
+## 2. Python
+
+Reference: PEP 8 as enforced by **ruff** (lint + format), **mypy**, and **pylint**.
+`pyproject.toml` and `.pylintrc` are authoritative; highlights:
+
+- **Formatting**: `ruff format` (black-compatible), line length **100**, 4-space indent.
+  No hand-aligned assignment columns — the formatter's output is canonical.
+- **Lint**: `ruff check` with `E, F, I, N, W, UP`. Imports sorted (ruff `I`), stdlib →
+  third-party → local, one import per line (no `import os, sys`).
+- **Types**: mypy clean. Type hints (PEP 604 unions, e.g. `int | None`) are **required**
+  for library-style code (`tb/models/`, `sim/`, `sw/`) and encouraged in test code.
+- **Pylint**: score ≥ 9.5 (`.pylintrc` `fail-under`); config lives in `.pylintrc` only.
+- **Docstrings**: Google style (`Args:` / `Returns:` / `Attributes:`). Every module starts
+  with a docstring — not a `#` comment block. Exemplar: `tb/models/rv32i_model.py`.
+- **No hardcoded absolute paths.** Derive paths from `__file__`, `Path.cwd()`, or
+  environment variables; scripts must run on any checkout.
+- **Errors**: no bare `except:`; catch specific exceptions; define domain exception
+  classes (`IllegalInstructionError` pattern in `tb/models/rv32i_model.py`).
+- **Constants**: named `UPPER_CASE` at module or class scope — no magic numbers in logic.
+- **Logging**: `print()` is acceptable only in CLI entry points; library code uses
+  `logging` or returns data.
+
+**Documented exceptions** (already encoded in `pyproject.toml`):
+
+- RISC-V mnemonic naming: uppercase function/variable names allowed via `N802`/`N806`
+  ignores (`sim/riscv_encoder.py`).
+- cocotb path bootstrapping: `sys.path.insert(...)` before local imports allowed via
+  `E402` ignores — but the insert must precede the import it enables, and be limited to
+  test entry points.
+- `tb/cocotb/cpu/legacy/` is frozen and excluded from all tooling.
+
+### 2.1 Test conventions
+
+- pytest: `test_*.py` / `Test*` / `test_*` (enforced by `[tool.pytest.ini_options]`).
+  Shared setup goes in `@pytest.fixture` (in `conftest.py`) rather than repeating
+  construction in every test.
+- **Assertions carry messages** when the bare expression doesn't make the failure
+  obvious: `assert cpu.regs[1] == 0, "x0 must remain zero"`.
+- cocotb: `@cocotb.test()` coroutines named `test_<feature>`; module docstring states
+  the DUT and scenarios; reuse the shared BFMs (`tb/cocotb/bfm/`) instead of ad-hoc
+  bus wiggling.
+
+---
+
+## 3. Shell and build scripts
+
+- Shebang: `#!/usr/bin/env bash` (not `#!/bin/bash`).
+- First non-comment line: `set -euo pipefail`.
+- New scripts are shellcheck-clean.
+- Makefiles: tabs for recipes (required by make; `.editorconfig` handles this),
+  `.PHONY` declared for non-file targets, tool-existence checks before use
+  (`command -v tool >/dev/null || { echo "ERROR..."; exit 1; }` — see `sim/Makefile`).
+
+---
+
+## 4. Commit messages
+
+Format: `[Category] Brief description` (imperative, ≤ 72 chars first line).
+
+Categories: `[Fix]`, `[Feature]`, `[Code]` (refactoring), `[Env]` (build/tooling),
+`[Doc]`, `[Test]`, `[Spec]`, `[RTL]` (RTL design work), `[PD]` (physical design),
+`[Analog]` (mixed-signal), `[Chore]` (maintenance).
+
+---
+
+## 5. Repository hygiene
+
+- **No committed build artifacts**: waveforms (`*.vcd`), sim outputs, `obj_dir/`,
+  P&R `runs/` directories are gitignored and must stay untracked.
+  **Documented exceptions** (P&R *inputs*, not outputs): macro `.lef`/`.lib` views,
+  gzipped macro netlists (`pnr/*/macro/*.nl.v.gz` — raw netlists exceed GitHub limits),
+  and the PLL GDS (`analog/pll_clkgen/sky130/layout/gds/`).
+- `.editorconfig` at repo root is the single source of truth for indent/EOL/whitespace;
+  editors and CI whitespace hooks defer to it.
+- Large files: pre-commit blocks additions > 500 KB (`check-added-large-files`).
+- Dead code is deleted, not commented out — history lives in git.
+
+---
+
+## 6. Enforcement summary
+
+| Layer | Tool | Scope | Gate |
+| :--- | :--- | :--- | :--- |
+| Editor | `.editorconfig` | whitespace/EOL, all files | advisory |
+| pre-commit | ruff, mypy, pylint, pytest-smoke, whitespace hooks | `tb/models`, `tb/tests`, `tb/cpu_uvm`, `sim` | blocking locally |
+| `sim/Makefile` | Verilator lint, Verible lint+format, CDC snitch | `rtl/**` | manual, run before commit |
+| CI `qa-checks.yml` | ruff format+lint, mypy, pylint, pytest+coverage | `tb/models`, `tb/tests` | **blocking** |
+| CI `rtl-checks.yml` | Verible lint (tree) + format (changed files) | `rtl/**` | non-blocking (adoption) |
+| CI `tests.yml` / `random_tests.yml` | pytest / cocotb regression | functional | blocking |
+
+Widening the enforced scope (cocotb lint, RTL hard gate, shellcheck) is tracked in the
+[compliance audit](CODING_COMPLIANCE_AUDIT.md) remediation plan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,21 +101,5 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-[tool.pylint.main]
-ignore = ["legacy"]
-recursive = true
-
-[tool.pylint."messages control"]
-disable = [
-    "C0301",  # line-too-long (handled by ruff)
-    "C0302",  # too-many-lines (acceptable for test files)
-    "C0413",  # wrong-import-position (intentional for path setup)
-    "C0411",  # wrong-import-order (handled by ruff)
-    "W0107",  # unnecessary-pass (needed for empty template methods)
-    "W0212",  # protected-access (acceptable in test code)
-    "W0613",  # unused-argument (needed for API compatibility)
-    "W0718",  # broad-exception-caught (intentional for test robustness)
-    "R0911",  # too-many-return-statements
-    "R1705",  # no-else-return (stylistic preference)
-    "R1714",  # consider-using-in (stylistic preference)
-]
+# Pylint config lives in .pylintrc (single source of truth — bare `pylint`
+# invocations in CI auto-load it). See docs/development/CODING_GUIDELINES.md.


### PR DESCRIPTION
## Summary

Establishes consolidated, industry-standard coding guidelines for the repo and audits the current codebase against them.

### New documents

- **`docs/development/CODING_GUIDELINES.md`** — coding practices for SystemVerilog (lowRISC style guide adapted to the existing house style), Python (PEP 8 via ruff/mypy/pylint), shell/Make, commit messages, and repo hygiene. Includes the mandated rules: module-scoped package imports, `*_pkg.sv` package file convention, and declaration-before-use. Policy: mandatory for new/modified code; existing verified RTL is grandfathered.
- **`docs/development/CODING_COMPLIANCE_AUDIT.md`** — audit vs the guidelines with `file:line` evidence: what already complies (one-module-per-file 100%, `always_ff`/`always_comb` only, uniform active-low resets, no `casex`, ...) and a prioritized P1/P2/P3 remediation backlog (license/SPDX, stale `micro_p/` tree, CI gating gaps, indent outliers, port-suffix/reset/naming harmonization).

### Config quick wins applied (no `.sv`/`.py` source files touched)

- Add `.editorconfig` (mechanically backs the 4-space house style).
- Delete dead `.flake8` — its blanket E501 ignore contradicted ruff's 100-col limit and it was wired into nothing.
- Merge `pyproject.toml [tool.pylint]` into `.pylintrc` as the single pylint config (CI's bare `pylint` and pre-commit previously used *different* rule sets); point the pre-commit hook at `.pylintrc`.
- Expand CLAUDE.md commit categories to actual usage (`[RTL]`, `[PD]`, `[Analog]`, `[Chore]`); link both new docs from README + CLAUDE.md.

## Verification

- `ruff format --check` / `ruff check` on `tb/models tb/tests`: clean
- `pylint tb/models tb/tests` with merged `.pylintrc` (mirrors CI's bare invocation): **9.97/10** (≥ 9.5 gate), same single pre-existing finding
- `pytest tb/tests`: **66/66 passed**
- `git diff --stat`: docs + configs only — zero RTL or Python source files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkkEy5XTe2v8dxqnxp7if2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkEy5XTe2v8dxqnxp7if2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added consolidated coding standards and compliance audit docs.
  * Updated project docs to surface the new guidance and related references.
  * Expanded commit message category guidance and coding rules in contributor docs.

* **Chores**
  * Added repo-wide editor settings for consistent formatting.
  * Simplified linting setup and aligned Pylint configuration to a single source.
  * Adjusted lint rules and defaults to better match the project’s current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->