### PR TITLE
[Env] cocotb: make the sim_build base directory configurable (bead f97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,12 @@ logs/
 *.vcd
 
 # cocotb
+# Bead claude_verilog_test-f97: BOTH forms are needed.  The trailing slash matches
+# only real directories, so with SIM_BUILD_ROOT pointed at scratch the in-tree
+# symlinks were left untracked-but-committable on any clone that lacks a local
+# .git/info/exclude entry.  The slashless form covers the symlinks.
 sim_build*/
+sim_build*
 __pycache__/
 *.pyc
 *.pyo

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -13,6 +13,16 @@ export PATH := $(HOME)/.local/bin:$(PATH)
 
 # Paths
 PROJ_ROOT := $(shell cd .. && pwd)
+
+# Bead claude_verilog_test-f97: base directory for the per-target sim_build dirs.
+# Defaults to `.`, so an unset environment behaves exactly as before.  These dirs
+# are large (sim_build_gpu_top alone is ~130 MB) and every one of them is
+# invalidated by any RTL edit.  Point it at scratch when root is tight:
+#   make SIM_BUILD_ROOT=/nobackup/claude_sim_build/sim gpu_all
+SIM_BUILD_ROOT ?= .
+ifeq ($(strip $(SIM_BUILD_ROOT)),)
+  $(error SIM_BUILD_ROOT is empty -- refusing to build or clean at the filesystem root)
+endif
 RTL_DIR := $(PROJ_ROOT)/rtl
 TB_DIR := $(PROJ_ROOT)/tb
 SIM_DIR := $(PROJ_ROOT)/sim
@@ -687,7 +697,7 @@ icache:
 		MODULE=tb.cocotb.mem.test_icache \
 		TOPLEVEL=rv32i_icache \
 		VERILOG_SOURCES="$(CACHE_SOURCES)" \
-		SIM_BUILD=sim_build_icache
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_icache
 
 # D-Cache unit tests (DUT = rv32i_dcache)
 .PHONY: dcache
@@ -699,7 +709,7 @@ dcache:
 		MODULE=tb.cocotb.mem.test_dcache \
 		TOPLEVEL=rv32i_dcache \
 		VERILOG_SOURCES="$(CACHE_SOURCES)" \
-		SIM_BUILD=sim_build_dcache
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_dcache
 
 # CPU + cache integration tests (DUT = rv32i_cpu_top)
 .PHONY: cache_integration
@@ -801,7 +811,7 @@ gpu_regfile:
 		MODULE=tb.cocotb.gpu.test_vector_regfile \
 		TOPLEVEL=vector_register_file \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/vector_register_file.sv" \
-		SIM_BUILD=sim_build_gpu_regfile
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_regfile
 
 # vector_alu unit tests
 .PHONY: gpu_alu
@@ -813,7 +823,7 @@ gpu_alu:
 		MODULE=tb.cocotb.gpu.test_vector_alu \
 		TOPLEVEL=vector_alu \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/vector_alu.sv" \
-		SIM_BUILD=sim_build_gpu_alu
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_alu
 
 # gpu_compute_unit unit tests (divergence)
 .PHONY: gpu_diverge
@@ -825,7 +835,7 @@ gpu_diverge:
 		MODULE=tb.cocotb.gpu.test_divergence \
 		TOPLEVEL=gpu_compute_unit \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/vector_register_file.sv $(RTL_DIR)/gpu/vector_alu.sv $(RTL_DIR)/gpu/gpu_compute_unit.sv" \
-		SIM_BUILD=sim_build_gpu_diverge
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_diverge
 
 # warp_scheduler unit tests
 .PHONY: gpu_sched
@@ -837,7 +847,7 @@ gpu_sched:
 		MODULE=tb.cocotb.gpu.test_warp_scheduler \
 		TOPLEVEL=warp_scheduler \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/warp_scheduler.sv" \
-		SIM_BUILD=sim_build_gpu_sched
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_sched
 
 # gpu_command_queue unit tests
 .PHONY: gpu_cmdq
@@ -849,7 +859,7 @@ gpu_cmdq:
 		MODULE=tb.cocotb.gpu.test_command_queue \
 		TOPLEVEL=gpu_command_queue \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/gpu_command_queue.sv" \
-		SIM_BUILD=sim_build_gpu_cmdq
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_cmdq
 
 # memory_coalescer unit tests
 .PHONY: gpu_coalescer
@@ -861,7 +871,7 @@ gpu_coalescer:
 		MODULE=tb.cocotb.gpu.test_memory_coalescer \
 		TOPLEVEL=memory_coalescer \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/memory_coalescer.sv" \
-		SIM_BUILD=sim_build_gpu_coalescer
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_coalescer
 
 # gpu_memory_unit unit tests (AXI master wrapper around memory_coalescer)
 .PHONY: gpu_memunit
@@ -873,7 +883,7 @@ gpu_memunit:
 		MODULE=tb.cocotb.gpu.test_memory_unit \
 		TOPLEVEL=gpu_memory_unit \
 		VERILOG_SOURCES="$(GPU_PKG) $(RTL_DIR)/gpu/memory_coalescer.sv $(RTL_DIR)/gpu/gpu_memory_unit.sv" \
-		SIM_BUILD=sim_build_gpu_memunit
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_memunit
 
 # gpu_top smoke tests (register bank + FSM)
 .PHONY: gpu_top_smoke
@@ -885,7 +895,7 @@ gpu_top_smoke:
 		MODULE=tb.cocotb.gpu.test_gpu_top \
 		TOPLEVEL=gpu_top \
 		VERILOG_SOURCES="$(GPU_SOURCES)" \
-		SIM_BUILD=sim_build_gpu_top
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_top
 
 # shared_memory unit tests
 .PHONY: gpu_shmem
@@ -897,7 +907,7 @@ gpu_shmem:
 		MODULE=tb.cocotb.gpu.test_shared_memory \
 		TOPLEVEL=shared_memory \
 		VERILOG_SOURCES="$(GPU_PKG) $(GPU_SRAM_SIM) $(RTL_DIR)/gpu/shared_memory.sv" \
-		SIM_BUILD=sim_build_gpu_shmem
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_shmem
 
 # All Phase 4 unit tests (leaf modules + compute pipeline)
 .PHONY: gpu_unit
@@ -945,7 +955,7 @@ gpu_kernels:
 		echo "Running kernel: $$module"; \
 		echo "========================================"; \
 		rm -f results.xml; \
-		if ! $(MAKE) sim MODULE=$$module TOPLEVEL=gpu_top VERILOG_SOURCES="$(GPU_SOURCES)" SIM_BUILD=sim_build_gpu_top || [ ! -f results.xml ] || grep -q '<failure\|<error' results.xml; then \
+		if ! $(MAKE) sim MODULE=$$module TOPLEVEL=gpu_top VERILOG_SOURCES="$(GPU_SOURCES)" SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_top || [ ! -f results.xml ] || grep -q '<failure\|<error' results.xml; then \
 			failed_tests="$$failed_tests $$module"; \
 		fi; \
 		echo ""; \
@@ -972,7 +982,7 @@ gpu_random:
 		MODULE=tb.cocotb.gpu.test_random_kernels \
 		TOPLEVEL=gpu_top \
 		VERILOG_SOURCES="$(GPU_SOURCES)" \
-		SIM_BUILD=sim_build_gpu_random \
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_random \
 		EXTRA_ARGS=""
 
 # Random-kernel smoke (25 kernels) — fast variant folded into gpu_all rollup.
@@ -992,7 +1002,7 @@ gpu_handoff:
 		MODULE=tb.cocotb.gpu.test_cpu_gpu_handoff \
 		TOPLEVEL=gpu_top \
 		VERILOG_SOURCES="$(GPU_SOURCES)" \
-		SIM_BUILD=sim_build_gpu_handoff
+		SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_gpu_handoff
 
 # All Phase 4 tests: unit + kernels + handoff + random smoke
 .PHONY: gpu_all
@@ -1065,6 +1075,15 @@ regression_full:
 		echo "========================================"; \
 	fi
 
+# Bead claude_verilog_test-f97: sweep $(SIM_BUILD_ROOT) rather than a hardcoded
+# CWD-relative list, so a relocated build dir is reclaimed instead of orphaned.
+# The glob also picks up targets added after this was written -- the old explicit
+# list had already drifted out of date.
+.PHONY: clean-sim-builds
+clean-sim-builds:
+	@rm -rf $(SIM_BUILD_ROOT)/sim_build $(SIM_BUILD_ROOT)/sim_build_* 2>/dev/null || true
+	@rm -rf ./sim_build ./sim_build_* 2>/dev/null || true
+
 # Use distclean to avoid conflict with cocotb's clean
 # Note: 'clean' target is only defined when cocotb Makefile is included
 distclean:
@@ -1072,10 +1091,7 @@ distclean:
 	@$(MAKE) clean 2>/dev/null || true
 	@rm -rf obj_dir 2>/dev/null || true
 	@rm -rf __pycache__ 2>/dev/null || true
-	@rm -rf sim_build sim_build_icache sim_build_dcache 2>/dev/null || true
-	@rm -rf sim_build_gpu_regfile sim_build_gpu_alu sim_build_gpu_diverge 2>/dev/null || true
-	@rm -rf sim_build_gpu_sched sim_build_gpu_cmdq sim_build_gpu_coalescer 2>/dev/null || true
-	@rm -rf sim_build_gpu_memunit sim_build_gpu_shmem sim_build_gpu_top sim_build_gpu_handoff 2>/dev/null || true
+	@$(MAKE) clean-sim-builds
 	@rm -f dump.vcd 2>/dev/null || true
 	@rm -f results.xml 2>/dev/null || true
 	@rm -f *.log 2>/dev/null || true

--- a/tb/cocotb/cpu/Makefile
+++ b/tb/cocotb/cpu/Makefile
@@ -10,6 +10,16 @@
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
 
+# Bead claude_verilog_test-f97: base directory for the build dir.  Defaults to
+# `.`, so an unset environment behaves exactly as before.  Point it at scratch
+# when the root filesystem is tight:
+#   make SIM_BUILD_ROOT=/nobackup/claude_sim_build/cpu
+SIM_BUILD_ROOT ?= .
+ifeq ($(strip $(SIM_BUILD_ROOT)),)
+  $(error SIM_BUILD_ROOT is empty -- refusing to build or clean at the filesystem root)
+endif
+SIM_BUILD ?= $(SIM_BUILD_ROOT)/sim_build
+
 # Python path: repo root must be on PYTHONPATH for `from tb.xxx import` to work
 export PYTHONPATH := $(PWD)/../../..:$(PYTHONPATH)
 
@@ -464,7 +474,13 @@ usage info:
 	@echo "  - cocotb Python package installed"
 
 # Custom clean target to avoid conflicts with cocotb's clean
-distclean: clean
+# Bead claude_verilog_test-f97: also sweep $(SIM_BUILD_ROOT) so a relocated
+# build dir is actually reclaimed rather than orphaned on the scratch FS.
+.PHONY: clean-sim-builds
+clean-sim-builds:
+	rm -rf $(SIM_BUILD_ROOT)/sim_build ./sim_build
+
+distclean: clean clean-sim-builds
 	@rm -rf __pycache__ 2>/dev/null || true
 	@rm -f *.vcd *.fst 2>/dev/null || true
 	@echo "Deep clean complete"

--- a/tb/cocotb/soc/Makefile
+++ b/tb/cocotb/soc/Makefile
@@ -11,6 +11,35 @@ RTL      := $(PROJ_ROOT)/rtl
 TB       := $(PROJ_ROOT)/tb/cocotb
 SIM_DIR  := $(PROJ_ROOT)/sim
 
+# Bead claude_verilog_test-f97: base directory for the per-target sim_build dirs.
+# Defaults to `.` so an unset environment behaves exactly as before (CI unchanged).
+# Point it at scratch when the root filesystem is tight, e.g.
+#   make SIM_BUILD_ROOT=/nobackup/claude_sim_build/soc soc_all
+# The 26 per-target dirs are ~190 MB each (~5 GB total) and EVERY one of them is
+# invalidated by any RTL edit, so a full soc_all rebuild needs several GB at once.
+# When that space is not there the run dies part-way and reports
+#   ERROR: results.xml was not written by the simulation!
+# AFTER the per-suite PASS lines -- an ENOSPC that does not look like one.
+# Same idea as the AMS cosim flow's SIM_BUILD routing (CLAUDE.md, PHASE7 plan).
+SIM_BUILD_ROOT ?= .
+ifeq ($(strip $(SIM_BUILD_ROOT)),)
+  $(error SIM_BUILD_ROOT is empty -- refusing to build or clean at the filesystem root)
+endif
+
+# Bead claude_verilog_test-f97: pre-flight free-space gate.  A full soc_all
+# rebuild writes ~5 GB of Verilator objects; running out mid-flight surfaces as
+# a post-PASS `results.xml was not written` error that reads like flaky infra.
+# Fail here instead, naming the real cause.  Override the floor if you know the
+# build is incremental: make SIM_BUILD_MIN_FREE_MB=500 soc_all
+SIM_BUILD_MIN_FREE_MB ?= 6000
+
+# NOTE: the check-space RECIPE lives at the bottom of this file, after the
+# cocotb `include`.  Any target defined before that include becomes make's
+# default goal, and the per-suite recipes re-invoke `$(MAKE) MODULE=... ` with
+# NO explicit target -- so a target up here silently replaces the cocotb `sim`
+# goal and every suite runs the check instead of the test, exiting 0 having
+# tested nothing.  Only the variables may live up here.
+
 # bfm/ lives in tb/cocotb (TB); slave model lives in this directory.
 export PYTHONPATH := $(TB):$(SOC_DIR):$(PYTHONPATH)
 
@@ -360,7 +389,7 @@ ifeq ($(SIM),verilator)
 # while the suite still reported 11/11 PASS. That is a false pass, strictly
 # worse than the VPI crash this bead started from, and it is only invisible
 # because TOPLEVEL happens to match. (Caught in review of PR #142.)
-BUILD_ARGS += SIM_BUILD=sim_build_$@$(if $(filter-out freepdk45,$(SRAM_TARGET)),_$(SRAM_TARGET))
+BUILD_ARGS += SIM_BUILD=$(SIM_BUILD_ROOT)/sim_build_$@$(if $(filter-out freepdk45,$(SRAM_TARGET)),_$(SRAM_TARGET))
 ifneq ($(wildcard /nix/store),)
 	# Nix environment: nix ld.so cannot find system libs when cocotb dlopen's
 	# libpython3.10.so.1.0.  Create a compat dir with symlinks to system libs.
@@ -777,7 +806,7 @@ l2_bench: l2_bench_lint
 #   ~95s combined (soc_multiclock ~93s dominated by test_multiclock_periph_loopback's
 #   UART/SPI bit-banging at the 7ns/3ns ratio; soc_pll_multiclock <1s) — comparable
 #   to soc_boot's own 100-attempt stability gate already in this list, so kept in.
-soc_all:
+soc_all: check-space
 	$(MAKE) crossbar
 	$(MAKE) register_bank
 	$(MAKE) axil_interconnect
@@ -836,6 +865,28 @@ soc_integration_batch: soc_boot_lint
 
 # Bead claude_verilog_test-7je: cocotb's own `clean` only removes $(SIM_BUILD),
 # which is now per-target, so it cannot sweep the others.
-.PHONY: distclean
-distclean:
-	rm -rf sim_build sim_build_*
+# Bead claude_verilog_test-f97: sweep $(SIM_BUILD_ROOT), not the CWD.  With the
+# dirs relocated, a CWD-relative `rm -rf sim_build_*` deleted only the local
+# symlinks and orphaned the real ~1.8 GB on the scratch filesystem.
+.PHONY: distclean clean-sim-builds
+distclean: clean-sim-builds
+
+clean-sim-builds:
+	rm -rf $(SIM_BUILD_ROOT)/sim_build $(SIM_BUILD_ROOT)/sim_build_*
+	@# Also clear any stale in-tree dirs/symlinks left by an earlier SIM_BUILD_ROOT.
+	rm -rf ./sim_build ./sim_build_*
+
+.PHONY: check-space
+check-space:
+	@mkdir -p $(SIM_BUILD_ROOT)
+	@free_mb=$$(df -Pm $(SIM_BUILD_ROOT) | awk 'NR==2 {print $$4}'); \
+	if [ "$$free_mb" -lt "$(SIM_BUILD_MIN_FREE_MB)" ]; then \
+	  echo "ERROR: only $${free_mb} MB free on the filesystem holding SIM_BUILD_ROOT=$(SIM_BUILD_ROOT)"; \
+	  echo "       a full rebuild of every sim_build dir needs >= $(SIM_BUILD_MIN_FREE_MB) MB."; \
+	  echo "       Point SIM_BUILD_ROOT at a bigger filesystem, e.g."; \
+	  echo "         make SIM_BUILD_ROOT=/nobackup/claude_sim_build/soc $(MAKECMDGOALS)"; \
+	  echo "       or reclaim space with: make clean-sim-builds"; \
+	  echo "       (override the floor with SIM_BUILD_MIN_FREE_MB=<n> if the build is incremental)"; \
+	  exit 1; \
+	fi; \
+	echo "check-space: $${free_mb} MB free at $(SIM_BUILD_ROOT) (floor $(SIM_BUILD_MIN_FREE_MB) MB) -- OK"


### PR DESCRIPTION
Closes bead `claude_verilog_test-f97`.

## Problem

The 26 per-target `sim_build` dirs under `tb/cocotb/soc` are ~190 MB each, and **every one of them is invalidated by any RTL edit**. On a root filesystem at 97% (4.3 GB free) a full `soc_all` rebuild needs several GB it doesn't have, so the run dies part-way and reports:

```
ERROR: results.xml was not written by the simulation!
```

— *after* every suite has already printed its `PASS` lines. An ENOSPC that looks like flaky infra, not a disk problem. Re-running the failing target standalone succeeds, which reinforces the wrong diagnosis.

Until now the only workaround was moving the dirs to scratch by hand and symlinking them back: local filesystem state, uncommitted, unshared, lost on a fresh clone.

## Fix

A `SIM_BUILD_ROOT` handle, defaulting to `.` so an unset environment behaves **exactly** as before:

```bash
make SIM_BUILD_ROOT=/nobackup/claude_sim_build/soc soc_all
```

Applied to all three schemes that existed:

| File | Before |
| :--- | :--- |
| `tb/cocotb/soc/Makefile:363` | one generic `SIM_BUILD=sim_build_$@…` |
| `tb/cocotb/cpu/Makefile` | never set `SIM_BUILD` at all — one shared 146 MB dir |
| `sim/Makefile` | 14 hardcoded literals across 16 dirs (`sim_build_gpu_top` alone is 130 MB) |

Bead `7je`'s per-target isolation and its `SRAM_TARGET` suffix are preserved untouched — only the base directory moves.

### Also fixed

- **`distclean` was hardcoded to CWD-relative names** in all three Makefiles. Against relocated dirs it deleted only the symlinks and **orphaned the real 1.8 GB** on scratch. All three now sweep `$(SIM_BUILD_ROOT)` via a new `clean-sim-builds` target. `sim/Makefile`'s explicit dir list had also drifted out of date and is replaced by a glob.
- **New `check-space` pre-flight gate** on `soc_all` fails loudly, naming the real cause and the fix, instead of dying mid-run.
- **`.gitignore` had `sim_build*/` only.** The trailing slash matches directories alone, so relocated symlinks were untracked-but-committable on any clone lacking a local `.git/info/exclude` entry. Added the slashless form.

## One trap worth flagging for reviewers

The `check-space` **recipe deliberately lives below the cocotb `include`.** Any target defined above it becomes make's default goal — and the per-suite recipes re-invoke `$(MAKE) MODULE=… ` with **no explicit target**. Placed at the top, it silently replaced the cocotb `sim` goal and the entire suite **exited 0 having tested nothing**. That is exactly the class of false-pass beads `7je` and `dwp` exist to prevent, so it is called out in an in-file comment. Only the *variables* may live at the top.

## Test plan

- [x] `soc_all` with `SIM_BUILD_ROOT=/nobackup/...` → **26 suites, TESTS=183 PASS=183 FAIL=0 SKIP=0**, zero error markers — matches the bead `a2g` baseline exactly
- [x] **0** in-tree `sim_build*` dirs afterwards; **26** on scratch; root FS unchanged at 4.3 GB free across the whole run
- [x] Unset `SIM_BUILD_ROOT` → `SIM_BUILD=./sim_build_timer`, i.e. path-identical to today (CI unaffected)
- [x] `.DEFAULT_GOAL` verified identical to `main` (`all`) — the trap above
- [x] Bead `7je` isolation intact: distinct `Vtop` md5 per target, and `sim_build_sram_controller` vs `sim_build_sram_controller_sky130` still differ
- [x] `check-space` fires correctly on the real 97%-full root and passes on scratch
- [x] `git check-ignore -v` now resolves sim_build dirs against `.gitignore`, not `.git/info/exclude`

Makefile/gitignore only — no RTL, no testbench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)