### PR TITLE
[Doc] pnr README/clean fixes lost from #148, + 16 rescued design_state entries

### DIFF
--- a/design_state.json
+++ b/design_state.json
@@ -1277,6 +1277,182 @@
       "suggested_next_step": "proceed",
       "reason": "APB migration PR-7 1M-cycle SoC stress PASS (feat/apb-mig-7-soctop commit 646624b): TESTS=1 PASS=1 FAIL=0. 10/10 outer iterations completed in 1,080,111 sim cycles / 257.7s wall-clock. UART/SPI/Timer/IRQ/PLL now routed through axil_to_apb->apb_interconnect APB4 subtree. Benchmarks (last iter): DMA mem->mem 26587 cycles; GPU kernel+flush 50538 cycles; Timer CNT0 snap 0x000ff926. FAIL_PC never committed. 0 UVM FATAL. 0 UVM ERROR. soc_all 95/95 + 1M-cycle stress clean -> APB migration fully signed off.",
       "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-21T07:43:00+07:00",
+      "agent": "rtl-design-orchestrator",
+      "stage": "lint_check",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Added SRAM_MEM_WORDS parameter (default 1024) to soc_top and tb_soc_top; lint clean \u2014 0 new errors, 0 new warnings.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-21T09:30:10Z",
+      "agent": "firmware-orchestrator",
+      "stage": "bsp_development",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "M10 bench scratch multi-slot append protocol: BENCH_SCRATCH_ADDR moved to 0x41C00 (1 KB region 0x41C00..0x41FFF); bench_init() added; bench_report() now appends to slot[count] (8 words/slot, max 31); __stack_top lowered to 0x41C00 in rv32i.ld; bench_init() called in all three mains. Build clean: hello/matmul/sweep zero -Wall/-Wextra warnings. All symbols below 0x41C00; sweep heap ends 0x122B0.",
+      "constraint_ref": "claude_verilog_test-kdj"
+    },
+    {
+      "timestamp": "2026-06-21T16:22:34.587702+07:00",
+      "agent": "firmware-orchestrator",
+      "stage": "bsp_development",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "M10-A3 bench build fixed: -Wl,--no-warn-mismatch added to Makefile; all 3 programs (hello/matmul/sweep) build clean with zero -Wall/-Wextra warnings; all symbols <0x42000; __heap_start below __stack_top/BENCH_SCRATCH_ADDR 0x41F00.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-21T17:02:00+07:00",
+      "agent": "firmware-orchestrator",
+      "stage": "bsp_development",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "crt0.S halt sequence patched: sw a0->__result then csrw 0x7C0 (dcache_flush) + 2048-iter drain spin + fence + ebreak. Build clean: hello/matmul/sweep zero -Wall/-Wextra warnings. sweep.dis confirms 7c001073 + drain loop at 0x2044-0x2054 before ebreak at 0x205c. Unblocks harness bead e4f.",
+      "constraint_ref": "claude_verilog_test-kdj"
+    },
+    {
+      "timestamp": "2026-06-21T17:30:00+07:00",
+      "agent": "firmware-orchestrator",
+      "stage": "peripheral_drivers",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "sweep.c tuned for tractable Verilator sim-time: 8 sizes->7 (max 32KB, 8x L1 cliff visible), 4 passes->1 prime+1 measured, STRIDE capped at 1024 accesses. Build clean zero -Wall/-Wextra warnings. bss ends 0xA320, all symbols < 0x41C00. 14 records (7x2). Bead claude_verilog_test-kdj.",
+      "constraint_ref": "claude_verilog_test-kdj"
+    },
+    {
+      "timestamp": "2026-06-21T19:20:00+07:00",
+      "agent": "verification-orchestrator",
+      "stage": "directed_tests",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "M10 sweep benchmark complete: TESTS=2 PASS=2 (test_hello_sanity + test_sweep_l2_bench). 14 records: D$miss/1k-instr = 0.00 for <=4KB, jumps to 50.0 SEQ / 189-197 STRIDE for >=8KB. L1 capacity cliff confirmed at 4KB->8KB boundary. l2_bench_results.md written. Bead e4f closed.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T00:07:00.535048+00:00",
+      "agent": "verification-orchestrator",
+      "stage": "directed_tests",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "M11 PD synth-readiness RTL rewrites (Synlig/UHDM packed-2D conversion) verified functionally equivalent. lint: 0 errors, 7 pre-existing baseline warnings only. soc_all: TESTS=82 PASS=82 FAIL=0 across 14 suites after 3 TB-only fixes (tb_axi4_crossbar.sv unpacked->packed-2D internals; tb_axi_lite_interconnect.sv same; test_axil_interconnect.py BAD_HIGH 0x2000_7000->0x2000_8000 for Phase 7 PLL slot). No DUT RTL changes required. DUT RTL is safe to commit.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T00:19:15.239447+00:00",
+      "agent": "physical-design-orchestrator",
+      "stage": "floorplan",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "M11 synthesis PASS: 4170 cells / 184.55 um2 peripheral logic; cpu_top + gpu_top as black-box macros confirmed in netlist. Fixes: SYNLIG_DEFER=true, json_header_patched.py wired, hierarchy -check removed from synthesize.py. Next: full P&R run.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T00:20:12.798466+00:00",
+      "agent": "rtl-design-orchestrator",
+      "stage": "lint_check",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Synlig UHDM intermediate-wire decoupling: all 11 submodule instances (u_cpu, u_gpu, u_dma, u_boot_rom, u_sram, u_periph_bridge, u_uart, u_spi, u_timer, u_irq_ctrl, u_pll_regs) in soc_top.sv now use named logic intermediates + assign bridges instead of indexed packed 2D array expressions in port connections; eliminates rtlil.cc:2150 assert(wire->name not empty). Verilator -Wall: 0 errors, 7 pre-existing baseline warnings only.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T05:50:00+07:00",
+      "agent": "rtl-design-orchestrator",
+      "stage": "rtl_coding",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Synlig/Surelog UHDM fix: all module-level unpacked arrays in axi4_crossbar.sv converted to packed 2D form (wstate_e[N_SLAVES-1:0], rstate_e[N_SLAVES-1:0], dwstate_e[N_MASTERS-1:0], drstate_e[N_MASTERS-1:0], and all logic [N-1:0][W-1:0] arb/capture/resolution arrays). Typedefs preserved; access syntax unchanged. Verilator 5.048 -Wall: 0 errors, 0 warnings on axi4_crossbar.sv; full make lint exits with 7 pre-existing baseline warnings only.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T06:26:00+07:00",
+      "agent": "rtl-design-orchestrator",
+      "stage": "lint_check",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Synlig/UHDM soc_top.sv packed-2D fix: 66 module-level unpacked array declarations in soc_top.sv, 30 port declarations in axi4_crossbar.sv, and 20 port declarations in axi_lite_interconnect.sv converted to packed 2D form; generate port-bridge blocks replaced with direct whole-array assigns. Verilator 5.048 -Wall: 0 errors, 7 pre-existing baseline warnings (unchanged).",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T11:30:00+07:00",
+      "agent": "verification-orchestrator",
+      "stage": "regression_signoff",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "Working-tree soc_top.sv (Synlig/UHDM intermediate-wire decoupling, 902 ins / 292 del) verified functionally equivalent. lint: 0 errors, 7 pre-existing baseline warnings (no new). soc_all: TESTS=82 PASS=82 FAIL=0 across 14 cocotb suites (crossbar 7/7, register_bank 6/6, axil 4/4, sram 8/8, dma 6/6, irq 5/5, timer 6/6, uart 11/11, spi 13/13, soc_boot 3/3, soc_periph 1/1, soc_coherency 3/3, soc_cpu_gpu 2/2, soc_pll 7/7). Top-level-wiring-critical suites all green. Safe to commit.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-22T14:03:50Z",
+      "agent": "physical-design-orchestrator",
+      "stage": "placement",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "tool_error",
+      "suggested_next_step": "proceed",
+      "reason": "Run 1 died at stage 29: PDN_MACRO_CONNECTIONS '.*u_sram.*' fatal exit \u2014 sram_controller flat-synthesized, not a hard macro. Fix: removed SRAM entry from PDN_MACRO_CONNECTIONS. Run 2 relaunched in tmux soc_pd.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-23T00:15:40.628955Z",
+      "agent": "physical-design-orchestrator",
+      "stage": "synthesis",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "none",
+      "suggested_next_step": "proceed",
+      "reason": "sv2v frontend breakthrough: SYNLIG UHDM cannot synthesize this SoC (SYNLIG_DEFER=true drops peripheral FSMs, SYNLIG_DEFER=false crashes in UHDM). sv2v 0.0.13.1 converts all SoC SV to Verilog-2005; Yosys read_verilog produces 43546 DFFs + 110K cells. Run 13 (RUN_2026-06-23_06-51-22) actively synthesizing.",
+      "constraint_ref": null
+    },
+    {
+      "timestamp": "2026-06-23T11:13:31.320931Z",
+      "agent": "physical-design-orchestrator",
+      "stage": "synthesis",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "timing",
+      "suggested_next_step": "proceed",
+      "reason": "Run 13 WNS=-364 ps diagnosed as CTS dual-tree from create_generated_clock; fixes committed and run 14 launched with CTS + SDC + Makefile corrections",
+      "constraint_ref": "phase5_soc.sdc"
+    },
+    {
+      "timestamp": "2026-06-23T22:23:36.085992+00:00",
+      "agent": "physical-design-orchestrator",
+      "stage": "signoff",
+      "decision": "proceed",
+      "confidence": "high",
+      "failure_class": "power_area",
+      "suggested_next_step": "proceed",
+      "reason": "Run 14 complete (WNS=0, DRC=0, Util=65.6%) but 8.28M PSM-0069 PG violations from macro abstract LEFs lacking PORT/RECT geometry; fixed by adding M7 perimeter PORT/RECT rings to both CPU and GPU LEFs; Run 15 launched",
+      "constraint_ref": null
     }
   ],
   "fix_requests": [

--- a/pnr/Makefile
+++ b/pnr/Makefile
@@ -1529,7 +1529,7 @@ schematic:
 clean:
 	@echo "Cleaning generated files..."
 	rm -rf $(WORK_DIR) $(LOGS_DIR) $(REPORTS_DIR) $(RESULTS_DIR) \
-		openlane/runs openlane1/runs \
+		$(OPENLANE1_DIR)/runs \
 		$(LIBRELANE_SKY130_DIR)/runs \
 		$(LIBRELANE_NANGATE45_DIR)/runs \
 		$(LIBRELANE_ASAP7_DIR)/runs

--- a/pnr/README.md
+++ b/pnr/README.md
@@ -72,9 +72,11 @@ Both superseded directories carry the stale `VERILOG_FILES` package-closure gap 
 `openlane/` (speculative OpenLane-2 scaffolding, never wired to any Makefile target) was deleted;
 LibreLane is the OL2-lineage tool this project uses.
 
-> **Note:** the Directory Structure and Quick Start sections above predate the per-node layout and
-> describe `make synth/place/route` targets that no longer exist. Treat `pnr/Makefile help` as the
-> authoritative target list.
+> **Two flows coexist here.** The *Usage* / *Quick Start* section above drives the standalone
+> Yosys + OpenROAD + OpenSTA script flow (`pnr/scripts/0*.tcl`, reading `pnr/config/` and
+> `pnr/constraints/`) — those targets are real and still work. The per-node directories in the
+> table below are the LibreLane flows, invoked through the `librelane-*` targets instead. Run
+> `make -C pnr help` for the authoritative target list.
 
 ## Phase-Specific Flows
 


### PR DESCRIPTION
Two independent items, both discovered while closing out the #148/#149/#150 merges.

---

# 1. Re-lands two fixes silently lost from #148

Commit `7c2cfa6` carried the right message but contained **only `.beads/issues.jsonl`** — its `git add` was part of a compound command a pre-commit hook rejected, so the add never ran and the commit picked up nothing but the auto-exported beads file. #148 merged the `pnr/openlane/` deletion **without either correction**.

CodeRabbit said exactly this — *"the inspected snapshot does not include the stated `7c2cfa6` README or `clean` changes"* — and it was right; not snapshot lag. Verified against `main`:

```
pnr/openlane deleted                     OK      (landed via #148)
README note: STILL WRONG                 not landed
Makefile clean: STILL has openlane/runs  not landed
```

### `pnr/README.md` — the note added in `de0deb5` was factually wrong

It claimed the Directory Structure and Quick Start sections *"describe `make synth/place/route` targets that no longer exist."* **Every one exists** in `pnr/Makefile`: `all synth place route sta report_timing report_power report_area clean`.

They drive the standalone Yosys + OpenROAD + OpenSTA script flow (`pnr/scripts/01_synth.tcl` … `08_power.tcl`, reading `pnr/config/` and `pnr/constraints/`) — exactly the layout the Directory Structure section describes, still present: `pnr/config` (1), `pnr/constraints` (19), `pnr/scripts` (15). Only `logs/` is absent, and the README already marks it gitignored.

Acting on the original note would have deleted docs for a working flow. The note now says what is actually true: **two flows coexist** here — the script flow, and the LibreLane per-node flows via `librelane-*` — and points at `make -C pnr help` (a real command; the old note gave `pnr/Makefile help`, which is not).

CodeRabbit independently re-ran this on #148, replied *"you are correct… I withdraw the finding"*, and recorded a repo learning.

### `pnr/Makefile` — dangling path introduced by `de0deb5`

`clean` still listed `openlane/runs` after `pnr/openlane/` was deleted. Harmless to `rm -rf`, but naming a path that no longer exists. Collapsed to `$(OPENLANE1_DIR)/runs`.

---

# 2. Recovers 16 more `design_state.json` history entries (follow-up to #149)

Before dropping the ten old stashes I re-verified their content was on `main`, and found a category #149 missed.

**#149 only inspected the files each stash *modified*.** A stash commit records the whole tree, so `git show stash@{9}:design_state.json` resolves even though that stash never touched it — and its base commit `73864f5` is **not an ancestor of `main`**. Sixteen entries live only there; dropping the stash would have orphaned them.

Recovered (2026-06-21 … 06-23, the M10/M11 period):

| Agent | Records |
| :--- | :--- |
| `firmware-orchestrator` | M10 bench scratch append protocol; `-Wl,--no-warn-mismatch` build fix; `crt0.S` halt sequence (dcache_flush + drain spin + fence); `sweep.c` tuned for tractable Verilator sim-time |
| `verification-orchestrator` | M10 sweep benchmark — D$ miss/1k-instr 0.00 below 4 KB, jumps at the L1 cliff — **the measurement behind the M10 L2 NO-GO** |
| `rtl-design-orchestrator` | `SRAM_MEM_WORDS`; Synlig/Surelog UHDM packed-2D conversion of `axi4_crossbar.sv` + `soc_top.sv`; intermediate-wire decoupling |
| `physical-design-orchestrator` | M11 synthesis PASS (4170 cells); `PDN_MACRO_CONNECTIONS u_sram` fatal; **the sv2v frontend breakthrough**; Run 13 WNS −364 ps CTS dual-tree diagnosis; Run 14 signoff + 8.28M PSM-0069 fix |

### Method note worth keeping

Uniqueness was established by **`(timestamp, agent, stage)`**, not exact string match. That distinction mattered: the same sweep flagged 33 "missing" records in `memory/pd/experiences.jsonl` that turned out to be **pure re-serialization — zero unique by logical identity**, so nothing was recovered from there. An exact-string test would have duplicated 33 records.

Strictly additive, same as #149: every pre-existing entry preserved in order, no other key touched, history **95 → 111**, diffstat **176 insertions / 0 deletions**.

---

## Test plan

- [x] Both files confirmed **staged** and confirmed present in the commit via `git show --numstat` — the exact step that failed silently last time
- [x] `make -C pnr help` parses and runs
- [x] `make -C pnr -n clean` expands cleanly
- [x] `design_state.json` parses; prior history byte-preserved in order; no other key changed
- [x] Docs, one Makefile line, and data — no RTL, no flow config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
