### PR TITLE
[RTL] Spyglass lint remediation (GH #116) — items A/B/C/E/F/G + waivers

### DIFF
--- a/lint/spyglass/waivers.awl
+++ b/lint/spyglass/waivers.awl
@@ -1,0 +1,148 @@
+# =============================================================================
+# Spyglass lint waiver file — phase5_soc / soc_top
+# =============================================================================
+# GH #116 — Spyglass lint violation remediation.
+# Plan: docs/development/SPYGLASS_LINT_REMEDIATION_PLAN.md (dispositions locked
+# with the user; this file implements section 3, "WAIVE + DOCUMENT items").
+#
+# Every waiver below carries a rationale explaining WHY the flagged construct
+# is intentional design behaviour, not a suppression of convenience. Do not
+# add a waiver here without a comment that would let a reviewer independently
+# judge whether the disposition is still correct.
+#
+# Format: standard SpyGlass `waive` directive.
+#   waive -rule <RULE> -scope <hierarchy|signal|file> -comment "<rationale>"
+# Load with: spyglass -waiver lint/spyglass/waivers.awl (or `read_waiver` in
+# the SpyGlass project script). Not exercised by this repo's own gates
+# (Verilator/Verible) — Spyglass is not installed in this environment; this
+# file is prepared for the next session/user that has SpyGlass access.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# K. SynchReset-ML (x56) — synchronous-reset CPU pipeline + peripherals
+# -----------------------------------------------------------------------------
+# Design intent, not an oversight: this project uses an ALL-SYNCHRONOUS reset
+# discipline end-to-end (CODING_GUIDELINES.md section 1.4), by explicit
+# architectural choice. The entire CPU pipeline (IF/ID/EX1a/EX1b/EX1c/EX2/MEM/
+# WB), rv32i_core, rv32i_csr_file, and every peripheral (uart_controller,
+# spi_controller, timer, interrupt_controller, dma_engine) reset on
+# `always_ff @(posedge clk)` with `if (!rst_n)` inside the clocked block —
+# never `posedge clk or negedge rst_n`. This was signed off at ASAP7 (1282 MHz
+# CPU standalone, 571 MHz SoC, run 14/run 23 — see docs/PHASE5_RUN_HISTORY.md)
+# and re-verified through the M11/M12 physical-design flow on this exact
+# reset structure. Converting to asynchronous reset is a SEPARATE, explicitly
+# out-of-scope effort (tracked as the existing P3 audit item in
+# CODING_GUIDELINES.md section 1.4) because it would require: (a) whole-CPU
+# functional re-verification (async reset changes recovery/removal timing and
+# can change first-cycle-after-reset behaviour), and (b) a full ASAP7 PPA
+# re-sign-off (reset tree becomes a real clock-like network needing its own
+# CTS/skew budget). GH #116 explicitly excludes this conversion.
+waive -rule SynchReset-ML -scope "soc_top.u_cpu.*" -comment "Intentional, signed-off synchronous-reset CPU pipeline (CODING_GUIDELINES.md 1.4). Async conversion is a separate P3 effort requiring full regression + ASAP7 PPA re-sign-off; explicitly out of scope for GH #116."
+waive -rule SynchReset-ML -scope "soc_top.u_uart.*" -comment "Intentional synchronous-reset peripheral discipline (CODING_GUIDELINES.md 1.4)."
+waive -rule SynchReset-ML -scope "soc_top.u_spi.*" -comment "Intentional synchronous-reset peripheral discipline (CODING_GUIDELINES.md 1.4)."
+waive -rule SynchReset-ML -scope "soc_top.u_timer.*" -comment "Intentional synchronous-reset peripheral discipline (CODING_GUIDELINES.md 1.4)."
+waive -rule SynchReset-ML -scope "soc_top.u_irq_ctrl.*" -comment "Intentional synchronous-reset peripheral discipline (CODING_GUIDELINES.md 1.4)."
+waive -rule SynchReset-ML -scope "soc_top.u_dma.*" -comment "Intentional synchronous-reset peripheral discipline (CODING_GUIDELINES.md 1.4)."
+
+
+# -----------------------------------------------------------------------------
+# I. STARC05-2.3.6.1 / UnInitializedReset-ML — no-reset arrays and local temps
+# -----------------------------------------------------------------------------
+# (a) No-reset memory/stack arrays: div_stack / div_depth in warp_scheduler.sv,
+# and every cache/register-file storage array (rv32i_dcache/icache data+tag
+# SRAM-equivalents, rv32i_regfile). Adding a reset mux across a multi-KB array
+# is a genuine area/timing cost for zero functional benefit — architectural
+# state (regfile x0..x31, cache lines, divergence stack entries) is defined by
+# software convention (x0 hardwired, cache tags qualified by a separate valid
+# bit that DOES reset, divergence stack entries qualified by div_depth which
+# DOES reset) rather than by a reset value on the storage itself. This is
+# standard SRAM/register-file design practice, not an omission.
+waive -rule STARC05-2.3.6.1 -scope "warp_scheduler.div_stack" -comment "No-reset divergence stack — depth-qualified by div_depth (which does reset); resetting the stack storage itself would add a wide mux for no functional benefit."
+waive -rule UnInitializedReset-ML -scope "warp_scheduler.div_stack" -comment "See STARC05-2.3.6.1 waiver above — depth-qualified, not consumed until div_depth confirms a valid entry."
+waive -rule STARC05-2.3.6.1 -scope "warp_scheduler.div_depth" -comment "See div_stack waiver — div_depth itself DOES reset (to 0) in the RTL; flagged only because it coexists with the no-reset div_stack array it qualifies."
+waive -rule STARC05-2.3.6.1 -scope "rv32i_regfile.regfile" -comment "Register file storage array — x0 is hardwired to zero at the read mux, not by resetting the storage; standard regfile practice, no reset value defines architectural state at power-on (firmware/boot code initializes live registers before use)."
+waive -rule STARC05-2.3.6.1 -scope "rv32i_dcache.*_array" -comment "Cache data/tag storage arrays — validity is carried by valid_array (which DOES reset, see GH #116 item B fix), not by the data/tag storage itself. Standard cache design practice."
+waive -rule STARC05-2.3.6.1 -scope "rv32i_icache.*_array" -comment "Cache data/tag storage arrays — validity is carried by valid_array (which DOES reset, see GH #116 item B fix), not by the data/tag storage itself. Standard cache design practice."
+#
+# (b) Local automatic temporaries assigned with blocking `=` inside an
+# always_ff — rv32i_csr_file.sv csr_cur/csr_nxt (declared and fully consumed
+# within the same always_ff iteration, never carrying state across clock
+# edges). Converting these to `<=` would be a FUNCTIONAL BUG: csr_nxt reads
+# csr_cur in the same statement, and both are recomputed from scratch every
+# cycle — they are not registers. Flagged only because the surrounding
+# always_ff block also contains real `<=` state updates.
+waive -rule STARC05-2.3.6.1 -scope "rv32i_csr_file.csr_cur" -comment "Local automatic temporary, blocking-assigned and fully consumed within the same always_ff iteration — not a flip-flop. Converting to <= would be a functional bug (see GH #116 plan section 2, item B)."
+waive -rule STARC05-2.3.6.1 -scope "rv32i_csr_file.csr_nxt" -comment "Local automatic temporary, blocking-assigned and fully consumed within the same always_ff iteration — not a flip-flop. Converting to <= would be a functional bug (see GH #116 plan section 2, item B)."
+waive -rule UnInitializedReset-ML -scope "rv32i_csr_file.csr_cur" -comment "See STARC05-2.3.6.1 waiver above — local temporary, not a register."
+waive -rule UnInitializedReset-ML -scope "rv32i_csr_file.csr_nxt" -comment "See STARC05-2.3.6.1 waiver above — local temporary, not a register."
+#
+# (c) Combinational defaults — rv32i_csr_file.sv `do_fire`. Assigned in every
+# case arm of a combinational (always_comb-equivalent) block with no reset
+# port at all; flagged only because the file elsewhere contains reset-bearing
+# always_ff blocks.
+waive -rule UnInitializedReset-ML -scope "rv32i_csr_file.do_fire" -comment "Purely combinational signal (no clock, no reset port) — computed fresh every cycle in a case statement with a default arm. False positive from proximity to the file's other, genuinely-registered always_ff blocks."
+#
+# (d) boot_rom.mem — falls out of GH #116 item C (initial-block guarding).
+# Once the parameter-check `initial` blocks in apb4_register_bank.sv /
+# axi_lite_register_bank.sv / axil_to_apb.sv are guarded (`ifndef __pnr__`),
+# a synthesis-view lint run that defines __pnr__ (matching the sky130 sv2v/
+# Yosys flow) sees boot_rom.mem as driven only inside its own pre-existing
+# `ifndef __pnr__` initial block (rtl/soc/boot_rom.sv, untouched by GH #116 —
+# see plan item D) — i.e. undriven from the synthesis view. This is inherent
+# to a $readmemh-loaded behavioral ROM: contents are supplied by the boot
+# flow / back-annotated at bring-up, not by RTL. A synthesizable case-based
+# ROM would lose the hex-file flexibility this behavioral SoC model relies on
+# — not recommended for this design.
+waive -rule UndrivenInTerm-ML -scope "soc_top.u_boot_rom.mem" -comment "Behavioral $readmemh-loaded ROM (rtl/soc/boot_rom.sv) — contents supplied by the boot flow / back-annotated at bring-up, not RTL-driven. Inherent to this ROM style; see GH #116 plan item D."
+
+
+# -----------------------------------------------------------------------------
+# J. W392 — core_rst_n "used with different polarity" (cross-module clash)
+# -----------------------------------------------------------------------------
+# False positive: soc_top.sv declares its own top-level net `core_rst_n`
+# (= rst_n_i & pll_locked, the PLL-gated reset distributed to CPU/GPU/fabric
+# children) alongside internally-scoped nets/parameters of similar name
+# inside child hierarchy (e.g. dma_engine's local reset wiring). SpyGlass's
+# W392 name-based polarity check compares these across module boundaries as
+# if they were the same signal purely because the base name matches after
+# hierarchy flattening; they are DIFFERENT nets in DIFFERENT scopes with no
+# electrical connection to each other, so there is no actual polarity
+# conflict — only a naming coincidence.
+waive -rule W392 -scope "soc_top.core_rst_n" -comment "Cross-module name collision, not a real polarity conflict — soc_top's top-level core_rst_n (rst_n_i & pll_locked) is a distinct net from any same-named local signal inside child module scopes (e.g. dma_engine); no electrical connection exists between them."
+waive -rule W392 -scope "dma_engine.*rst_n*" -comment "See soc_top.core_rst_n waiver above — same false-positive class from SpyGlass's name-based cross-hierarchy polarity check."
+
+
+# -----------------------------------------------------------------------------
+# H. STARC05-2.10.3.1 — PLL_IMPL == "RNM" string-parameter compare
+# -----------------------------------------------------------------------------
+# rtl/soc/pll/pll_clkgen.sv:63 `if (PLL_IMPL == "RNM") begin : g_rnm` selects,
+# at ELABORATION time, between the RNM (real-number model, analog cosim) and
+# STUB (pure digital passthrough) PLL implementations via a `generate` guard.
+# STARC05-2.10.3.1 flags the operand-width mismatch between a `string`
+# parameter and a string literal — this is not real hardware: no comparator
+# is synthesized: the branch not taken is elaborated away entirely. Optional
+# future refactor (not required to close GH #116): map PLL_IMPL to a
+# `localparam int` selector to silence this without a waiver.
+waive -rule STARC05-2.10.3.1 -scope "pll_clkgen.PLL_IMPL" -comment "Elaboration-time string-parameter compare selecting an RNM-vs-STUB `generate` branch (rtl/soc/pll/pll_clkgen.sv:63) — not synthesized hardware, no comparator exists in the gate-level netlist."
+
+
+# -----------------------------------------------------------------------------
+# G (residual). SignedUnsignedExpr-ML — functionally-required signed math /
+#                string parameters
+# -----------------------------------------------------------------------------
+# rv32i_alu.sv:78 `ALU_SRA: result = $signed(operand_a) >>> shamt;` — RV32I's
+# SRA instruction is defined as an ARITHMETIC (sign-extending) right shift;
+# the `$signed()` cast is functionally REQUIRED, not incidental. "Fixing"
+# this to unsigned would silently break every SRA instruction (logical
+# instead of arithmetic shift) — see GH #116 plan section 2, item G.
+waive -rule SignedUnsignedExpr-ML -scope "rv32i_alu.result" -comment "$signed(operand_a) >>> shamt implements RV32I SRA (arithmetic right shift) — signedness here is functionally required, not an unintended mix. See GH #116 plan section 2, item G."
+#
+# `parameter string` declarations — string parameters are benign; SpyGlass's
+# signed/unsigned check does not meaningfully apply to a `string` type
+# (elaboration-time only, never synthesized as a signed/unsigned bit vector).
+waive -rule SignedUnsignedExpr-ML -scope "soc_top.MEM_INIT_FILE" -comment "parameter string — elaboration-time only, not a synthesized bit vector; signed/unsigned does not apply."
+waive -rule SignedUnsignedExpr-ML -scope "soc_top.PLL_IMPL" -comment "parameter string — elaboration-time only, not a synthesized bit vector; signed/unsigned does not apply."
+waive -rule SignedUnsignedExpr-ML -scope "boot_rom.MEM_INIT_FILE" -comment "parameter string — elaboration-time only, not a synthesized bit vector; signed/unsigned does not apply. (rtl/soc/boot_rom.sv is unmodified by GH #116 — see plan items C/D exclusions.)"
+waive -rule SignedUnsignedExpr-ML -scope "pll_subsystem.PLL_IMPL" -comment "parameter string — elaboration-time only, not a synthesized bit vector; signed/unsigned does not apply."
+waive -rule SignedUnsignedExpr-ML -scope "pll_clkgen.PLL_IMPL" -comment "parameter string — elaboration-time only, not a synthesized bit vector; signed/unsigned does not apply."

--- a/lint/spyglass/waivers.awl
+++ b/lint/spyglass/waivers.awl
@@ -110,7 +110,7 @@ waive -rule UndrivenInTerm-ML -scope "soc_top.u_boot_rom.mem" -comment "Behavior
 # electrical connection to each other, so there is no actual polarity
 # conflict — only a naming coincidence.
 waive -rule W392 -scope "soc_top.core_rst_n" -comment "Cross-module name collision, not a real polarity conflict — soc_top's top-level core_rst_n (rst_n_i & pll_locked) is a distinct net from any same-named local signal inside child module scopes (e.g. dma_engine); no electrical connection exists between them."
-waive -rule W392 -scope "dma_engine.*rst_n*" -comment "See soc_top.core_rst_n waiver above — same false-positive class from SpyGlass's name-based cross-hierarchy polarity check."
+waive -rule W392 -scope "dma_engine.rst_n" -comment "See soc_top.core_rst_n waiver above — same false-positive class from SpyGlass's name-based cross-hierarchy polarity check."
 
 
 # -----------------------------------------------------------------------------

--- a/rtl/cpu/core/pipeline/rv32i_pipeline_ex.sv
+++ b/rtl/cpu/core/pipeline/rv32i_pipeline_ex.sv
@@ -20,8 +20,6 @@
 // NOTE: ex_pc_redirect / trap / mret / fence_i / dbg_halt come from EX1b.
 // Branch misprediction penalty is 4 cycles (EX1c stage adds one cycle).
 
-`default_nettype none
-
 import rv32i_pipeline_pkg::*;
 module rv32i_pipeline_ex(
     input  logic        clk,
@@ -180,4 +178,3 @@ module rv32i_pipeline_ex(
 
 endmodule
 
-`default_nettype wire

--- a/rtl/cpu/core/pipeline/rv32i_pipeline_ex1b.sv
+++ b/rtl/cpu/core/pipeline/rv32i_pipeline_ex1b.sv
@@ -16,8 +16,6 @@
 // combinationally from EX1b using the registered dec_do_redirect /
 // dec_redirect_target rather than a case-mux derived value.
 
-`default_nettype none
-
 import rv32i_pipeline_pkg::*;
 module rv32i_pipeline_ex1b (
     // ── EX1a combinational wire input ─────────────────────────────────────────
@@ -120,4 +118,3 @@ module rv32i_pipeline_ex1b (
 
 endmodule
 
-`default_nettype wire

--- a/rtl/cpu/core/pipeline/rv32i_pipeline_ex1c.sv
+++ b/rtl/cpu/core/pipeline/rv32i_pipeline_ex1c.sv
@@ -23,8 +23,6 @@
 //
 // Branch misprediction penalty: 4 cycles (unchanged from Run-20).
 
-`default_nettype none
-
 import rv32i_pipeline_pkg::*;
 module rv32i_pipeline_ex1c (
     // ── Registered EX1a output (ex1a_ex1b_reg_q from rv32i_core.sv) ──────────
@@ -208,4 +206,3 @@ module rv32i_pipeline_ex1c (
 
 endmodule
 
-`default_nettype wire

--- a/rtl/cpu/core/pipeline/rv32i_pipeline_ex1c.sv
+++ b/rtl/cpu/core/pipeline/rv32i_pipeline_ex1c.sv
@@ -150,8 +150,7 @@ module rv32i_pipeline_ex1c (
                     end
                 endcase
             end
-            3'b010: begin  // Word store — defaults already set above
-            end
+            3'b010: ;  // Word store — defaults already set above
             default: begin
                 ex1c_o.pre_wstrb         = 4'b0000;
                 ex1c_o.pre_wdata_aligned = 32'h0;

--- a/rtl/cpu/core/pipeline/rv32i_pipeline_ex2.sv
+++ b/rtl/cpu/core/pipeline/rv32i_pipeline_ex2.sv
@@ -7,8 +7,6 @@
 // This splits the former single EX combinational cone into two independent
 // timing windows, targeting ~200 ps WNS improvement on ASAP7.
 
-`default_nettype none
-
 import rv32i_pipeline_pkg::*;
 module rv32i_pipeline_ex2 (
     input  logic          clk_i,
@@ -53,4 +51,3 @@ module rv32i_pipeline_ex2 (
 
 endmodule
 
-`default_nettype wire

--- a/rtl/cpu/core/pipeline/rv32i_pipeline_if.sv
+++ b/rtl/cpu/core/pipeline/rv32i_pipeline_if.sv
@@ -143,6 +143,7 @@ module rv32i_pipeline_if #(
             if_id_reg_o.valid       <= 1'b1;
         end else if (stall_if_id) begin
             // Hold current IF/ID (downstream stall)
+            if_id_reg_o <= if_id_reg_o;
         end else begin
             // No valid instruction this cycle (e.g. cache miss, halt, redirect)
             if_id_reg_o <= if_id_nop();

--- a/rtl/cpu/core/rv32i_alu.sv
+++ b/rtl/cpu/core/rv32i_alu.sv
@@ -73,6 +73,8 @@ module rv32i_alu (
       ALU_SLTU: result = {31'b0, ~sum[32]};
       ALU_XOR:  result = operand_a ^ operand_b;
       ALU_SRL:  result = operand_a >> shamt;
+      // Spyglass SignedUnsignedExpr-ML: waived (lint/spyglass/waivers.awl) —
+      // arithmetic right shift is functionally required to be signed (RV32I SRA).
       ALU_SRA:  result = $signed(operand_a) >>> shamt;
       ALU_OR:   result = operand_a | operand_b;
       ALU_AND:  result = operand_a & operand_b;

--- a/rtl/cpu/core/rv32i_control.sv
+++ b/rtl/cpu/core/rv32i_control.sv
@@ -501,11 +501,9 @@ module rv32i_control (
       // ------------------------------------------------------------
       // EXECUTE
       // ------------------------------------------------------------
-      EXECUTE: begin
-        // Branch/jump decision is latched in pc_src_execute register
-        // and used in WRITEBACK state
-        // (no pc_src setting needed here)
-      end
+      // Branch/jump decision is latched in pc_src_execute register and used
+      // in WRITEBACK state (no pc_src setting needed here).
+      EXECUTE: ;
 
       // ------------------------------------------------------------
       // MEM_WAIT

--- a/rtl/cpu/core/rv32i_decode.sv
+++ b/rtl/cpu/core/rv32i_decode.sv
@@ -505,10 +505,9 @@ module rv32i_decode (
           end else begin
             illegal = 1'b1;
           end
-        end else if (funct3 == 3'b000) begin
-          // FENCE (funct3=000): NOP in a single-CPU design (no coherence).
-          // No action; illegal remains 0.
-        end else begin
+        end else if (funct3 == 3'b000) ;  // FENCE: NOP in a single-CPU design
+                                           // (no coherence); illegal remains 0.
+        else begin
           // Other funct3 encodings are reserved/illegal.
           illegal = 1'b1;
         end

--- a/rtl/cpu/core/rv32i_forwarding_unit.sv
+++ b/rtl/cpu/core/rv32i_forwarding_unit.sv
@@ -20,7 +20,6 @@
 //   (producer completed EX1b and is currently in ex1b_ex2_reg_q, waiting for EX2)
 //   Priority: between fwd_*_ex1c and 2'b01.
 
-`default_nettype none
 module rv32i_forwarding_unit (
     // Forwarding selects from hazard unit
     input  logic [1:0]  fwd_a_sel,
@@ -224,4 +223,3 @@ module rv32i_forwarding_unit (
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/gpu_command_queue.sv
+++ b/rtl/gpu/gpu_command_queue.sv
@@ -4,7 +4,6 @@
 // On launch_i pulse: latch the kernel descriptor and assert desc_valid_o.
 // New launches while busy_o are silently dropped (gpu_top guards with idle check).
 // On desc_ack_i: clear valid so a new descriptor can be accepted.
-`default_nettype none
 
 module gpu_command_queue
     import gpu_pkg::*;
@@ -75,4 +74,3 @@ module gpu_command_queue
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/gpu_compute_unit.sv
+++ b/rtl/gpu/gpu_compute_unit.sv
@@ -473,9 +473,8 @@ module gpu_compute_unit
                         end
                     end
 
-                    IC_VSYNC: begin
-                        // Intra-warp VSYNC: Phase 4 passes immediately (single CU)
-                    end
+                    // Intra-warp VSYNC: Phase 4 passes immediately (single CU)
+                    IC_VSYNC: ;
 
                     default: ; // IC_INVALID
                 endcase

--- a/rtl/gpu/gpu_compute_unit.sv
+++ b/rtl/gpu/gpu_compute_unit.sv
@@ -15,7 +15,6 @@
 //
 // NOTE: Human review required before merge (divergence algorithm,
 //       memory stall interaction, reconverge logic).
-`default_nettype none
 
 module gpu_compute_unit
     import gpu_pkg::*;
@@ -526,4 +525,3 @@ module gpu_compute_unit
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/gpu_memory_unit.sv
+++ b/rtl/gpu/gpu_memory_unit.sv
@@ -8,7 +8,6 @@
 // stalled; that is safe because the compute unit's pipe_stall causes the
 // result to be captured from rdata_o only when stall_o drops, not one
 // cycle earlier.
-`default_nettype none
 
 module gpu_memory_unit
     import gpu_pkg::*;
@@ -103,4 +102,3 @@ module gpu_memory_unit
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/gpu_top.sv
+++ b/rtl/gpu/gpu_top.sv
@@ -15,7 +15,6 @@
 //   0x024 GPU_ARG_PTR
 //   0x028 GPU_IRQ_CLR   [0]=W1C
 //   0x030–0x06C GPU_PERFCNT[0..15]  (RO)
-`default_nettype none
 
 module gpu_top
     import gpu_pkg::*;
@@ -505,4 +504,3 @@ module gpu_top
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/gpu_top.sv
+++ b/rtl/gpu/gpu_top.sv
@@ -248,7 +248,7 @@ module gpu_top
     logic [WARP_W-1:0] n_warps_w;
     logic [9:0]        n_warps_raw;
     assign n_warps_raw = {3'b0, cq_desc.block_x[9:3]} + {9'b0, |cq_desc.block_x[2:0]};
-    assign n_warps_w   = |n_warps_raw[9:WARP_W] ? WARP_W'(N_WARPS-1) : n_warps_raw[WARP_W-1:0];
+    assign n_warps_w   = |n_warps_raw[9:WARP_W] ? unsigned'(WARP_W'(N_WARPS-1)) : n_warps_raw[WARP_W-1:0];
 
     always_ff @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin

--- a/rtl/gpu/memory_coalescer.sv
+++ b/rtl/gpu/memory_coalescer.sv
@@ -13,7 +13,6 @@
 //        → (load) AR → R → next lane or DONE
 //        → (store) AW → W → B → next lane or DONE
 //   DONE: assert done_o for one cycle, then return to IDLE.
-`default_nettype none
 
 module memory_coalescer
     import gpu_pkg::*;
@@ -213,4 +212,3 @@ module memory_coalescer
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/shared_memory.sv
+++ b/rtl/gpu/shared_memory.sv
@@ -20,7 +20,6 @@
 //   - sh_stall_o stays high for the whole access (issue + read-capture),
 //   - sh_rvalid_o pulses (while sh_stall_o is still high) the cycle every
 //     rdata_q is valid, mirroring the gpu_memory_unit (VLD) capture contract.
-`default_nettype none
 
 module shared_memory
     import gpu_pkg::*;
@@ -202,4 +201,3 @@ module shared_memory
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/vector_alu.sv
+++ b/rtl/gpu/vector_alu.sv
@@ -1,7 +1,6 @@
 // 8-lane vector ALU. All operations are single-cycle combinational.
 // Inactive lanes (active_mask bit = 0) produce 0 on result_o and branch_taken_o.
 // VMUL produces the lower 32 bits of the 64-bit product (no pipeline stage in Phase 4).
-`default_nettype none
 
 module vector_alu
     import gpu_pkg::*;
@@ -80,4 +79,3 @@ module vector_alu
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/vector_register_file.sv
+++ b/rtl/gpu/vector_register_file.sv
@@ -7,7 +7,6 @@
 // write enable so yosys infers a $mem cell for every lane.  A single
 // monolithic 256×256-bit array with per-lane sub-word write-enables blocks
 // $mem inference and causes a 65 536-DFF explosion in TECHMAP/ABC.
-`default_nettype none
 
 module vector_register_file
     import gpu_pkg::*;
@@ -66,4 +65,3 @@ module vector_register_file
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/warp_scheduler.sv
+++ b/rtl/gpu/warp_scheduler.sv
@@ -108,11 +108,11 @@ module warp_scheduler
         next_warp = rr_ptr;
         found     = 1'b0;
         for (int i = 0; i < N_WARPS; i++) begin
-            int cand_i;
-            cand_i = (int'(rr_ptr) + i) % N_WARPS;
-            if (!found && cand_i < int'(n_warps_q) &&
+            logic [WARP_W-1:0] cand_i;
+            cand_i = WARP_W'((int'(rr_ptr) + i) % N_WARPS);
+            if (!found && (cand_i < n_warps_q) &&
                 !warp_busy[cand_i] && !warp_done[cand_i]) begin
-                next_warp = WARP_W'(cand_i);
+                next_warp = cand_i;
                 found     = 1'b1;
             end
         end
@@ -132,7 +132,7 @@ module warp_scheduler
     // single-warp kernels where next_warp wraps to an invalid index).
     assign div_stack_depth_o = div_depth[exec_warp_id_i];
     assign div_stack_top_o   = (div_depth[exec_warp_id_i] != '0) ?
-                                div_stack[exec_warp_id_i][int'(div_depth[exec_warp_id_i]) - 1] :
+                                div_stack[exec_warp_id_i][div_depth[exec_warp_id_i] - 1'b1] :
                                 '0;
 
     // -----------------------------------------------------------------------

--- a/rtl/gpu/warp_scheduler.sv
+++ b/rtl/gpu/warp_scheduler.sv
@@ -7,7 +7,6 @@
 // Round-robin: starting from rr_ptr, scan forward to find the first warp
 // that is neither busy nor done. Issue it and advance rr_ptr.
 // When all warps are done: assert kernel_done_o.
-`default_nettype none
 
 module warp_scheduler
     import gpu_pkg::*;
@@ -230,4 +229,3 @@ module warp_scheduler
 
 endmodule
 
-`default_nettype wire

--- a/rtl/gpu/warp_scheduler.sv
+++ b/rtl/gpu/warp_scheduler.sv
@@ -78,6 +78,25 @@ module warp_scheduler
 );
 
     // -----------------------------------------------------------------------
+    // Parameter contract: N_WARPS_P sizes the per-warp arrays below, but the
+    // round-robin scan, reset/launch/completion loops and the `% N_WARPS` wrap
+    // are all bounded by the package constant N_WARPS, and the warp-id width
+    // WARP_W (and therefore n_warps_active_i) is derived from N_WARPS too.
+    // An override BELOW N_WARPS would index these arrays out of range; an
+    // override ABOVE it would leave the extra entries permanently unreachable
+    // and unrepresentable in WARP_W bits.  Nothing overrides it today
+    // (gpu_top.sv instantiates `warp_scheduler u_sched` with no parameter
+    // block), so this is latent rather than live -- but it is silent, so make
+    // it loud.  Generate-scope $fatal, not `initial $fatal`, so it fires under
+    // lint/synth elaboration and not only in simulation; same idiom as
+    // rtl/soc/cdc/cdc_2ff_sync.sv:82-84.
+    // -----------------------------------------------------------------------
+    if (N_WARPS_P != N_WARPS) begin : g_n_warps_p_check
+        $fatal(1, "warp_scheduler: N_WARPS_P (%0d) must equal gpu_pkg::N_WARPS (%0d) -- the scan/reset loops and WARP_W are bound to N_WARPS",
+               N_WARPS_P, N_WARPS);
+    end
+
+    // -----------------------------------------------------------------------
     // Per-warp state
     // -----------------------------------------------------------------------
     logic [31:0]             warp_pc    [N_WARPS_P-1:0];

--- a/rtl/mem/rv32i_cache_arbiter.sv
+++ b/rtl/mem/rv32i_cache_arbiter.sv
@@ -171,13 +171,12 @@ module rv32i_cache_arbiter (
                 axi_arvalid_o = dc_arvalid_i;
                 dc_arready_o  = axi_arready_i;
             end
-            GRANT_NONE: begin
-                // Do NOT forward AR beats during GRANT_NONE.
-                // The read-data routing (ic_rvalid_o / dc_rvalid_o) is gated
-                // on grant_q, so any AR that completes while grant_q==GRANT_NONE
-                // would produce rdata with no valid destination.  Wait one cycle
-                // for the FSM to register the grant before forwarding AR.
-            end
+            // Do NOT forward AR beats during GRANT_NONE.
+            // The read-data routing (ic_rvalid_o / dc_rvalid_o) is gated
+            // on grant_q, so any AR that completes while grant_q==GRANT_NONE
+            // would produce rdata with no valid destination.  Wait one cycle
+            // for the FSM to register the grant before forwarding AR.
+            GRANT_NONE: ;
             default: ;
         endcase
     end

--- a/rtl/mem/rv32i_dcache.sv
+++ b/rtl/mem/rv32i_dcache.sv
@@ -949,8 +949,8 @@ module rv32i_dcache (
     always_ff @(posedge clk) begin
         if (!rst_n) begin
             for (int j = 0; j < N_SETS; j++) begin
-                valid_array[j] = 1'b0;
-                dirty_array[j] = 1'b0;
+                valid_array[j] <= 1'b0;
+                dirty_array[j] <= 1'b0;
             end
         end else begin
             // Write hit: set dirty

--- a/rtl/mem/rv32i_icache.sv
+++ b/rtl/mem/rv32i_icache.sv
@@ -602,7 +602,7 @@ module rv32i_icache (
         if (!rst_n || ic_invalidate_i) begin
             // Reset or FENCE.I: invalidate all lines in one cycle
             for (int j = 0; j < N_SETS; j++)
-                valid_array[j] = 1'b0;
+                valid_array[j] <= 1'b0;
         end else if (tag_we_q) begin
             // tag_we_q is the registered version of tag_write_commit (the last-beat
             // commit qualifier).  Marking valid here ensures the line is considered

--- a/rtl/periph/dma_engine.sv
+++ b/rtl/periph/dma_engine.sv
@@ -27,8 +27,6 @@
 // Flat per-channel AXI ports (no SV interfaces) per Phase 5 RTL convention.
 // Lint target: verilator -Wall 0 errors 0 warnings.
 
-`default_nettype none
-
 module dma_engine
     import axi_pkg::*;
 #(
@@ -612,4 +610,3 @@ module dma_engine
 
 endmodule : dma_engine
 
-`default_nettype wire

--- a/rtl/periph/dma_engine.sv
+++ b/rtl/periph/dma_engine.sv
@@ -381,9 +381,8 @@ module dma_engine
             S_B: begin
                 m_bready = 1'b1;
             end
-            default: begin
-                // S_IDLE, S_CALC, S_DESC_DONE, S_ERR — all AXI outputs stay at defaults
-            end
+            // S_IDLE, S_CALC, S_DESC_DONE, S_ERR — all AXI outputs stay at defaults
+            default: ;
         endcase
     end
 

--- a/rtl/periph/interrupt_controller.sv
+++ b/rtl/periph/interrupt_controller.sv
@@ -21,8 +21,6 @@
 //
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 
-`default_nettype none
-
 module interrupt_controller
 #(
     parameter int unsigned ADDR_W    = 12,   // APB4 local address width

--- a/rtl/periph/spi_controller.sv
+++ b/rtl/periph/spi_controller.sv
@@ -43,8 +43,6 @@
 //
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 
-`default_nettype none
-
 module spi_controller #(
     parameter int unsigned ADDR_W = 12   // APB4 local address width
 ) (
@@ -498,4 +496,3 @@ module spi_controller #(
 
 endmodule : spi_controller
 
-`default_nettype wire

--- a/rtl/periph/timer.sv
+++ b/rtl/periph/timer.sv
@@ -20,8 +20,6 @@
 //
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 
-`default_nettype none
-
 module timer
 #(
     parameter int unsigned ADDR_W  = 12,  // APB4 local address width

--- a/rtl/periph/uart_controller.sv
+++ b/rtl/periph/uart_controller.sv
@@ -39,8 +39,6 @@
 //
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 
-`default_nettype none
-
 module uart_controller #(
     parameter int unsigned ADDR_W = 12   // APB4 local address width
 ) (
@@ -660,4 +658,3 @@ module uart_controller #(
 
 endmodule : uart_controller
 
-`default_nettype wire

--- a/rtl/soc/apb4_register_bank.sv
+++ b/rtl/soc/apb4_register_bank.sv
@@ -52,11 +52,14 @@ module apb4_register_bank #(
     input  logic [31:0] hw_wdata_i[N_REGS]   // hardware write data (bypasses WMASK)
 );
 
-    // Static width checks.
+    // Static width checks (simulation only — synthesis/lint views never
+    // instantiate DW/SW outside 32/4, and $fatal is non-synthesizable).
+`ifndef __pnr__
     initial begin
         if (DW != 32) $fatal(1, "apb4_register_bank requires DW == 32");
         if (SW != 4)  $fatal(1, "apb4_register_bank requires SW == 4");
     end
+`endif
 
     // Word index widths: WORDW spans the full ADDR_W slot; IDXW indexes N_REGS.
     localparam int unsigned WORDW = ADDR_W - 2;

--- a/rtl/soc/apb4_register_bank.sv
+++ b/rtl/soc/apb4_register_bank.sv
@@ -21,8 +21,6 @@
 // Lint note: paddr[1:0] are unused (word-aligned register file); they are
 // bracketed with a targeted lint_off to keep -Wall clean.
 
-`default_nettype none
-
 module apb4_register_bank #(
     parameter int unsigned N_REGS    = 16,
     parameter int unsigned ADDR_W    = 12,           // local byte address width
@@ -122,4 +120,3 @@ module apb4_register_bank #(
 
 endmodule : apb4_register_bank
 
-`default_nettype wire

--- a/rtl/soc/apb_cdc_bridge.sv
+++ b/rtl/soc/apb_cdc_bridge.sv
@@ -290,8 +290,6 @@
 // cdc_reset_sync discipline.
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 
-`default_nettype none
-
 module apb_cdc_bridge #(
     parameter int unsigned ADDR_W           = 12,  // APB4 local address width (byte address)
     parameter int unsigned SYNC_STAGES_TO_S = 2,    // stages synchronising INTO the s_* domain (ack, s reset, m_rst_n_i status)

--- a/rtl/soc/apb_interconnect.sv
+++ b/rtl/soc/apb_interconnect.sv
@@ -12,8 +12,6 @@
 // All logic is combinational — APB timing handshake (SETUP/ACCESS/pready) is
 // the responsibility of each downstream slave.
 
-`default_nettype none
-
 module apb_interconnect #(
     parameter int unsigned N_SLAVES = 1,
     parameter int unsigned ADDR_W   = 32,
@@ -103,4 +101,3 @@ module apb_interconnect #(
 
 endmodule : apb_interconnect
 
-`default_nettype wire

--- a/rtl/soc/axi4_to_axilite.sv
+++ b/rtl/soc/axi4_to_axilite.sv
@@ -23,8 +23,6 @@
 //
 // Lint target: verilator -Wall 0 errors 0 warnings.
 
-`default_nettype none
-
 module axi4_to_axilite
     import axi_pkg::*;
 #(

--- a/rtl/soc/axi_lite_register_bank.sv
+++ b/rtl/soc/axi_lite_register_bank.sv
@@ -71,11 +71,14 @@ module axi_lite_register_bank #(
 
     import axi_pkg::*;
 
-    // Static checks: module storage is fixed at 32-bit words with 4-byte strobes.
+    // Static checks: module storage is fixed at 32-bit words with 4-byte
+    // strobes (simulation only — $fatal is non-synthesizable).
+`ifndef __pnr__
     initial begin
         if (DW != 32) $fatal(1, "axi_lite_register_bank requires DW == 32");
         if (SW != 4)  $fatal(1, "axi_lite_register_bank requires SW == 4");
     end
+`endif
 
     logic [31:0] regs [N_REGS];
     assign regs_o = regs;

--- a/rtl/soc/axil_to_apb.sv
+++ b/rtl/soc/axil_to_apb.sv
@@ -87,11 +87,13 @@ module axil_to_apb #(
 
     import axi_pkg::*;
 
-    // Static width checks.
+    // Static width checks (simulation only — $fatal is non-synthesizable).
+`ifndef __pnr__
     initial begin
         if (DW != 32) $fatal(1, "axil_to_apb requires DW == 32");
         if (SW != 4)  $fatal(1, "axil_to_apb requires SW == 4");
     end
+`endif
 
     // ── FSM ──────────────────────────────────────────────────────────────────
     typedef enum logic [2:0] {

--- a/rtl/soc/axil_to_apb.sv
+++ b/rtl/soc/axil_to_apb.sv
@@ -35,8 +35,6 @@
 //   * paddr[1:0] unused on APB side (word-aligned slave) — suppressed in the
 //     slave (apb4_register_bank); forwarded verbatim here (bridge is transparent).
 
-`default_nettype none
-
 module axil_to_apb #(
     parameter int unsigned ADDR_W = 32,              // AXI-Lite / APB address width
     parameter int unsigned DW     = 32,              // Data width — must be 32
@@ -237,4 +235,3 @@ module axil_to_apb #(
 
 endmodule : axil_to_apb
 
-`default_nettype wire

--- a/rtl/soc/axilite_to_axi4.sv
+++ b/rtl/soc/axilite_to_axi4.sv
@@ -33,8 +33,6 @@
 //
 // Lint target: verilator -Wall 0 errors 0 warnings.
 
-`default_nettype none
-
 module axilite_to_axi4
     import axi_pkg::*;
 #(

--- a/rtl/soc/boot_rom.sv
+++ b/rtl/soc/boot_rom.sv
@@ -12,13 +12,12 @@
 // Ports mirror sram_controller.sv exactly so the crossbar can use either
 // as a generic AXI4 slave.
 //
-// Coding conventions: `default_nettype none, synchronous reset, no #delays,
-// no initial blocks in synthesisable path.  $readmemh is in an initial block
+// Coding conventions: no `default_nettype` directive (Spyglass IND,
+// CODING_GUIDELINES.md sec 1.3), synchronous reset, no #delays, no initial
+// blocks in synthesisable path.  $readmemh is in an initial block
 // (behavioral ROM pre-load, identical pattern to sram_controller.sv).
 //
 // Lint target: verilator -Wall 0 errors 0 warnings.
-
-`default_nettype none
 
 module boot_rom
     import axi_pkg::*;

--- a/rtl/soc/pll/pll_apb_regs.sv
+++ b/rtl/soc/pll/pll_apb_regs.sv
@@ -36,11 +36,9 @@
 //   * No logic — structural instantiation + assign only
 //   * Always-on domain (clk_i): config bus runs at ref clock
 //   * No `timescale directive
-//   * `default_nettype none
+//   * No `default_nettype` directive (Spyglass IND, CODING_GUIDELINES.md §1.3)
 //
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
-
-`default_nettype none
 
 module pll_apb_regs #(
     parameter int unsigned ADDR_W = 12  // local byte address width (4 KB slot)
@@ -146,4 +144,3 @@ module pll_apb_regs #(
 
 endmodule : pll_apb_regs
 
-`default_nettype wire

--- a/rtl/soc/pll/pll_clkgen.sv
+++ b/rtl/soc/pll/pll_clkgen.sv
@@ -29,8 +29,6 @@
 //   The RNM branch is present in the generate block but pruned when
 //   PLL_IMPL != "RNM"; pll_rnm.sv is excluded from the lint source list.
 
-`default_nettype none
-
 module pll_clkgen #(
     // Implementation selector — "STUB" (default, synth-safe) or "RNM" (cosim)
     parameter string   PLL_IMPL        = "STUB",
@@ -96,4 +94,3 @@ module pll_clkgen #(
 
 endmodule : pll_clkgen
 
-`default_nettype wire

--- a/rtl/soc/pll/pll_clkgen_stub.sv
+++ b/rtl/soc/pll/pll_clkgen_stub.sv
@@ -25,11 +25,9 @@
 // Coding rules:
 //   * No #delays, no initial blocks, no real types
 //   * All registers synchronous reset (active-low)
-//   * `default_nettype none enforced by parent wrapper
+//   * No `default_nettype` directive (Spyglass IND, CODING_GUIDELINES.md §1.3)
 //
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
-
-`default_nettype none
 
 module pll_clkgen_stub #(
     // Number of ref_clk_i rising edges to wait before asserting locked_o.
@@ -72,4 +70,3 @@ module pll_clkgen_stub #(
 
 endmodule : pll_clkgen_stub
 
-`default_nettype wire

--- a/rtl/soc/pll/pll_subsystem.sv
+++ b/rtl/soc/pll/pll_subsystem.sv
@@ -49,8 +49,6 @@
 // Coding rules: no logic — structural instantiation + assign only.
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 
-`default_nettype none
-
 module pll_subsystem #(
     // PLL implementation selector — "STUB" (default, synth-safe) or "RNM" (cosim)
     parameter string       PLL_IMPL        = "STUB",
@@ -144,4 +142,3 @@ module pll_subsystem #(
 
 endmodule : pll_subsystem
 
-`default_nettype wire

--- a/rtl/soc/soc_bus.sv
+++ b/rtl/soc/soc_bus.sv
@@ -24,8 +24,6 @@
 //
 // Lint: verilator -Wall 0 errors 0 warnings (same baseline as pre-refactor).
 
-`default_nettype none
-
 module soc_bus
     import axi_pkg::*;
     import soc_addr_map_pkg::*;

--- a/rtl/soc/soc_top.sv
+++ b/rtl/soc/soc_top.sv
@@ -153,8 +153,6 @@
 //
 // Lint target: verilator -Wall 0 errors 0 warnings.
 
-`default_nettype none
-
 module soc_top
     import axi_pkg::*;
     import soc_addr_map_pkg::*;


### PR DESCRIPTION
Closes #116 (Spyglass lint violation remediation).

Executes the committed plan `docs/development/SPYGLASS_LINT_REMEDIATION_PLAN.md`, whose fix-vs-waive dispositions were locked with the user. RTL work delegated to the rtl-design-orchestrator per the project's delegation policy; every verification claim below was then re-checked independently against the tree.

## What changed

| Item | Rule | Change |
| :--- | :--- | :--- |
| **A** | IND | Removed **all** `default_nettype` directives — **34 files**, not the 31 the plan lists (`pmu.sv`, `cdc_2ff_sync.sv`, `apb_cdc_bridge.sv` were added after it was drafted) |
| **B** | SM_BNP / W336 | `=` → `<=` in the i/d-cache valid/dirty `always_ff` reset loops |
| **C** | SM_IGN_INITIAL / W430 / W213 | Guarded the param-check `initial $fatal` blocks in `apb4_register_bank.sv`, `axi_lite_register_bank.sv`, `axil_to_apb.sv` |
| **E** | W192 | Empty `begin/end` → null statement |
| **F** | LINT_IMPROPER_RANGE_INDEX | `warp_scheduler.sv` `cand_i`: `int` → `logic [WARP_W-1:0]` |
| **G** | SignedUnsignedExpr-ML | Explicit casts where the mix was unintended; functionally-required signed math waived |
| **D/H/I/J/K** | — | New `lint/spyglass/waivers.awl` (148 lines), each waiver carrying its design-intent rationale |

## Item C uses `__pnr__`, not `SYNTHESIS` — and why that matters

The issue assumed the synth macro was `SYNTHESIS`. **It is defined by nothing in this toolchain.** The only occurrence is `pnr/freepdk45/config.json` `LINTER_DEFINES`, which feeds only the Verilator lint step — and `librelane/steps/verilator.py:140` reads `LINTER_DEFINES or VERILOG_DEFINES`, an `or`, so it *replaces* rather than merges. Neither sv2v nor Yosys auto-defines it. The guards as specified would have been a **silent no-op on every path**.

`__pnr__` already carries exactly these semantics and is already plumbed through both the sv2v and Yosys layers on sky130. Using it avoids a second macro that would have to be kept in lockstep with `boot_rom.sv`'s existing `__pnr__` branch.

`boot_rom.sv` keeps both its `__pnr__` branches untouched — only its `default_nettype` directive was removed. A `SYNTHESIS` wrapper there would have left a `parameter string` in the synthesis netlist, which is precisely what that branch exists to prevent.

## The ASAP7 sign-off baseline is provably untouched

ASAP7 deliberately does **not** pass `__pnr__` (`pnr/Makefile:1044-1049`; run-14 was signed off without it). So the new guards must be **inert on ASAP7 and active on sky130** — an asymmetry that belongs to bead `61v`, not to a lint cleanup.

Verified by regenerating the ASAP7 netlist from a clean `origin/main` worktree and diffing against this branch. After normalising the absolute path and line-number noise that sv2v bakes into `$display` strings:

```
added = 0     removed = 26     (all 26 are `default_nettype` directives)
```

**Zero other changes.** `default_nettype` is a compiler directive, not logic — no cells, no PPA impact.

Guard asymmetry confirmed directly: `requires DW == 32` appears **3×** in the ASAP7 netlist and **0×** in sky130.

## Verification (re-checked independently, not taken on report)

| Check | Result |
| :--- | :--- |
| `soc_all` | **26 suites, TESTS=183 PASS=183 FAIL=0**, 0 error markers, all builds on scratch |
| `make -C sim lint_soc` | 0 errors both sides. Warnings **7 → 4** |
| sv2v, both flows | ASAP7 28/28 modules, sky130 29/29, no blackboxing |
| `check_source_closure.py` | 4 `[GAP]` before and after — zero new |
| `make -C sim phase3_all` | 5/5 PASS |
| `make -C sim verible` | Tool absent from this environment — unavailable, not a failure |

### The lint result needed a second look, and got one

Item A **removes a check**, so "lint is clean" is weak evidence by construction: a warning that vanishes because the check no longer exists looks identical to one that was fixed. So the warning *sets* were diffed in both directions.

The only delta is **3× `BLKSEQ` disappearing**, at exactly `rv32i_icache.sv:605`, `rv32i_dcache.sv:952`, `rv32i_dcache.sv:953` — precisely the three lines item B changed. `BLKSEQ` is Verilator's blocking-in-sequential check and is entirely independent of `default_nettype`; it remains active. Those warnings were **fixed, not silenced**.

`DECLFILENAME` ×1 and `UNUSEDPARAM` ×3 are byte-identical before and after. `IMPLICIT` / `UNDRIVEN` / `WIDTH` / `UNUSEDSIGNAL`: **0 in both**.

## The cost of item A, stated plainly

Removing `default_nettype none` from 34 files gives up Verilator's implicit-wire catch: **a typo'd signal name now becomes a silent 1-bit wire instead of a compile error.** Nothing is broken today — 0 errors, 0 implicit-wire warnings — but the loss is prospective, and real. This was a locked user decision driven by a Spyglass conflict, not a cleanup without a downside.

## Out of scope

`rtl/soc/pll/pll_rnm.sv` is untouched. It guards itself with `// synthesis translate_off`, and **sv2v strips comments** (`grep -c translate_off` on the generated netlist → 0), so that pattern is unsafe on any sv2v path here. It is not in any P&R filelist, so it is not currently exposed — but the pattern must not be copied. Worth its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pipeline stall handling by explicitly preserving instruction state during downstream stalls.
  - Corrected sequential cache reset and invalidation assignments for more predictable hardware behavior.

- **Build & Validation**
  - Improved compatibility with place-and-route builds by isolating simulation-only parameter checks.
  - Added documented lint exceptions and refined width and signed-arithmetic handling across CPU, GPU, memory, and peripheral logic.

- **Maintenance**
  - Simplified RTL conventions without changing module interfaces or intended functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->