### PR TITLE
[RTL] Convergent CDC randomised settling-delay injector (bead rvs)

### DIFF
--- a/rtl/soc/cdc/cdc_2ff_sync.sv
+++ b/rtl/soc/cdc/cdc_2ff_sync.sv
@@ -29,31 +29,54 @@
 // Lint target: verilator -Wall -Wno-IMPORTSTAR 0 errors 0 warnings.
 //
 // ── On simulating CDC delay (bead claude_verilog_test-rvs) ────────────────
-// This module has NO simulation-time delay injection. An attempt at one was
-// reverted before merge because its model was wrong (it could latch a hold
-// permanently and stick the synchroniser rather than delaying it by a cycle).
+// This module now carries an optional simulation-time randomised settling-
+// delay injector on stage 0 of the flop array (RAND_CDC_DELAY_EN, default
+// OFF at every instantiation site). This is the SECOND attempt: the first
+// (commit 4197139) landed as disabled scaffolding and was reverted (commit
+// be485fd) because its model was wrong — it could latch a hold permanently
+// and stick the synchroniser instead of delaying it by a cycle. See "Why
+// this converges" below for the precise difference.
 //
-// The finding that motivated it stands and is worth recording here, because
-// this repo has repeatedly written the opposite: the claim that "metastability
-// injection is not modelable in Verilator/cocotb" (design_state.json, CLAUDE.md,
-// several test docstrings) is imprecise. What IS modelable, and what OpenTitan
-// actually does, is a randomised EXTRA-CYCLE-OF-SETTLING-DELAY on a
-// synchroniser's first stage — plain RTL, no timing control, so it works in a
-// 2-state cycle-based simulator. That is precisely the fault model that
-// reproduces a same-edge-assumption bug, which is the class this repo hit twice
-// in GH #93 (fr_57f49b7f9b29 and fr_280f3ac18c66) and which every 1:1-ratio,
+// The finding that motivated this stands regardless of either attempt's
+// fate, and is worth recording here because this repo has repeatedly
+// written the opposite: the claim that "metastability injection is not
+// modelable in Verilator/cocotb" (design_state.json, CLAUDE.md, several test
+// docstrings) is imprecise. What IS modelable, and what OpenTitan actually
+// does, is a randomised EXTRA-CYCLE-OF-SETTLING-DELAY on a synchroniser's
+// first stage — plain RTL, no timing control, so it works in a 2-state
+// cycle-based simulator. That is precisely the fault model that reproduces a
+// same-edge-assumption bug, which is the class this repo hit twice in GH #93
+// (fr_57f49b7f9b29 and fr_280f3ac18c66) and which every 1:1-ratio,
 // lockstep-reset unit test was structurally blind to.
 //
-// What remains genuinely NOT modelable here is analog metastability itself — an
-// intermediate, non-0/1, potentially oscillating voltage on Q. 4-state X
-// injection at the setup/hold boundary is a different and heavier technique.
+// What remains genuinely NOT modelable here is analog metastability itself —
+// an intermediate, non-0/1, potentially oscillating voltage on Q. 4-state X
+// injection at the setup/hold boundary is a different and heavier technique
+// this module does not attempt.
 //
-// Reference for a correct implementation, should bead rvs be picked up
-// (Apache-2.0, lowRISC contributors — note it takes BOTH src_data_i and
-// prev_data_i and is evaluated in the DESTINATION clock's process, which is
-// exactly what makes it converge):
+// Ported from (Apache-2.0, lowRISC contributors — concept and reset/seed
+// discipline adapted to this repo's house style, not a verbatim copy):
 //   https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
 //   https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim_generic/rtl/prim_flop_2sync.sv
+//
+// Why this converges where the reverted attempt did not: the reverted
+// version redrew its hold decision (`hold_sel`) ONLY inside `always @(d_i)`,
+// with nothing that ever cleared it back to 0 once d_i stopped moving — so a
+// hold could latch and stage0_d = sync_q[0] became a permanent self-loop
+// (measured: forcing it on gave async_axi_fifo TESTS=26 PASS=3 FAIL=23).
+// This version instead tracks `d_prev_q`, a plain register that is updated
+// EVERY destination-clock edge unconditionally (`d_prev_q <= d_i`, no
+// dependence on the hold decision). The hold decision is only even DRAWN
+// while `d_i !== d_prev_q`, and because d_prev_q always catches up to d_i on
+// the very next edge regardless of what was decided, that window can never
+// span more than one destination-clock cycle — there is no state here that
+// can persist once d_i has settled. This is the same guarantee OpenTitan's
+// own design provides via a differently-shaped mechanism (an unconditional
+// synchronous clear of `data_sel` on every posedge, racing a combinational,
+// event-gated re-arm on `src_data_i`) — both designs take BOTH the new
+// source value and the previously-captured value and evaluate the decision
+// in the DESTINATION clock's process, which is exactly the property the
+// reverted attempt lacked.
 //
 // Per house style: no `default_nettype` directive (Spyglass IND, CODING
 // GUIDELINES §1.3) — matching pmu.sv:123 and the sibling cdc_reset_sync.sv /
@@ -62,7 +85,27 @@
 
 module cdc_2ff_sync #(
     parameter int unsigned WIDTH  = 1,
-    parameter int unsigned STAGES = 2
+    parameter int unsigned STAGES = 2,
+
+    // Simulation-only randomised settling-delay injection on stage 0 (see
+    // header). Defeatable per instance; OFF by default at every existing
+    // instantiation site, so today's bit-exact deterministic regression is
+    // unaffected unless a testbench explicitly opts in. Unused outside
+    // `ifdef SIMULATION (every synthesis/lint/CDC-gate elaboration) — same
+    // pattern as pll_clkgen.sv's RNM params.
+    /* verilator lint_off UNUSEDPARAM */
+    parameter bit          RAND_CDC_DELAY_EN   = 1'b0,
+    // Percent chance [0,100), drawn once per destination-clock edge at which
+    // d_i is found to differ from what was captured on the previous edge,
+    // that stage 0 "misses" this edge's update and re-latches its own
+    // currently-held value (sync_q[0]) instead.
+    parameter int unsigned RAND_CDC_DELAY_PCT  = 32'd50,
+    // Reseeds this instance's own random stream once, at time 0, independent
+    // of the surrounding simulation's global seed — reproducible run to run
+    // for a given (SEED, RAND_CDC_DELAY_PCT, stimulus) combination, instead
+    // of depending on an outer harness seed nobody pinned.
+    parameter int unsigned RAND_CDC_DELAY_SEED = 32'hCDC2_5EED
+    /* verilator lint_on  UNUSEDPARAM */
 ) (
     // ── Destination-domain clock/reset ───────────────────────────────────────
     input  logic             clk_i,
@@ -87,13 +130,61 @@ module cdc_2ff_sync #(
     (* magic_cdc *)
     logic [WIDTH-1:0] sync_q [STAGES];
 
+`ifdef SIMULATION
+    // stage0_d: what actually gets clocked into sync_q[0] on the next
+    // destination-clock edge. Equals d_i unless RAND_CDC_DELAY_EN=1 injects
+    // a "missed edge" (see g_rand_cdc_delay below). Declared/driven ONLY
+    // under `ifdef SIMULATION — absent from every synthesis/lint/CDC-gate
+    // elaboration, so it cannot affect the synthesised netlist.
+    logic [WIDTH-1:0] stage0_d;
+
+    if (RAND_CDC_DELAY_EN) begin : g_rand_cdc_delay
+        // Tracks d_i unconditionally, every destination-clock edge, with NO
+        // dependence on the hold decision below. This is what guarantees
+        // self-clearing convergence (see "Why this converges" in the header)
+        // — d_prev_q always catches up to d_i on the very next edge whether
+        // or not that edge's capture was held.
+        logic [WIDTH-1:0] d_prev_q;
+
+        initial void'($urandom(RAND_CDC_DELAY_SEED));
+
+        always_ff @(posedge clk_i or negedge rst_n_i) begin
+            if (!rst_n_i) begin
+                d_prev_q <= '0;
+            end else begin
+                d_prev_q <= d_i;
+            end
+        end
+
+        // Draw a hold decision only while a source change is pending capture
+        // (d_i differs from what the previous edge saw). That window is at
+        // most one destination-clock cycle wide by construction (d_prev_q
+        // above), so a "hold" here can delay sync_q[0] by at most one extra
+        // cycle — it can never persist once d_i has settled.
+        always_comb begin
+            stage0_d = d_i;
+            if (d_i !== d_prev_q) begin
+                if ($urandom_range(0, 99) < RAND_CDC_DELAY_PCT) begin
+                    stage0_d = sync_q[0];
+                end
+            end
+        end
+    end else begin : g_no_rand_cdc_delay
+        assign stage0_d = d_i;
+    end
+`endif
+
     always_ff @(posedge clk_i or negedge rst_n_i) begin
         if (!rst_n_i) begin
             for (int unsigned i = 0; i < STAGES; i++) begin
                 sync_q[i] <= '0;
             end
         end else begin
+`ifdef SIMULATION
+            sync_q[0] <= stage0_d;
+`else
             sync_q[0] <= d_i;
+`endif
             for (int unsigned i = 1; i < STAGES; i++) begin
                 sync_q[i] <= sync_q[i-1];
             end

--- a/tb/cocotb/soc/Makefile
+++ b/tb/cocotb/soc/Makefile
@@ -342,6 +342,15 @@ ifeq ($(SIM),verilator)
 	COMPILE_ARGS += -Wno-CASEINCOMPLETE
 	COMPILE_ARGS += -Wno-TIMESCALEMOD
 	COMPILE_ARGS += -Wno-UNOPTFLAT
+	# bead claude_verilog_test-rvs: gates rtl/soc/cdc/cdc_2ff_sync.sv's
+	# optional simulation-only randomised-delay CDC injector (RAND_CDC_DELAY_EN,
+	# default OFF at every instantiation site — this define alone changes
+	# nothing observable). Never defined for sim/Makefile's lint_soc or the
+	# tools/cdc/ sv2v+yosys CDC-gate flow, so the synthesis/lint/CDC-gate
+	# paths stay bit-identical; only actual cocotb simulation runs (this
+	# Makefile) can see the injector at all, and only instances that
+	# explicitly override RAND_CDC_DELAY_EN=1 activate it.
+	COMPILE_ARGS += +define+SIMULATION
 	COMPILE_ARGS += --timescale 1ns/1ps
 	COMPILE_ARGS += --public-flat-rw
 	COMPILE_ARGS += --no-timing


### PR DESCRIPTION
## Summary

Redo of the CDC randomised settling-delay injector (bead `rvs`), after the first attempt was withdrawn as non-convergent.

`cdc_2ff_sync` gains an optional randomised extra-settling-delay mode, off by default, so simulations can model a synchroniser output taking longer than the nominal 2 flops to settle — the class of bug that a 1:1 clock-ratio testbench structurally cannot expose.

## Why the first attempt failed, and what changed

The first version gated its hold on a `hold_sel` term that itself depended on the held value, forming a self-loop that could refuse to converge.

This version tracks `d_prev_q` **unconditionally on every destination-domain edge**, independent of whether a delay is currently being applied. The injected delay then compares against a value that is always advancing, so there is no feedback path from the hold decision back into the hold condition.

## Evidence

**Standalone harness** — against a deliberately broken synchroniser:

| injector | detections |
| :--- | ---: |
| OFF | 0 / 2010 |
| ON | 304 / 2010 |

**Regression, injector OFF** — `soc_all`: **26 suites, 183/183 PASS, 0 FAIL, 0 SKIP**, `EXITCODE=0`. Default-off behaviour is unchanged.

## Negative results — stated as negative

Two honest misses, both reported rather than worked around:

- **Criterion 2 not met.** Commit `7a9f9d4` (`cdc_gray_fifo`'s `wr_ready_o` not gated by `wr_rst_n_i`) is *same-domain reset gating*, orthogonal to a settling-delay fault model. It is caught with the injector **OFF** too, so it does not demonstrate the feature's value.
- **In-design mutant experiment: no discrimination.** `cdc_gray_fifo`'s `full_q` comparison was temporarily made to bypass `u_rd_ptr_to_wr` and read `rd_gray_q` (pre-sync) instead of `rd_gray_sync_w`. `test_async_axi_fifo` gave **26/26 PASS both with the injector OFF and ON**.

  This is a clean negative result with a structural explanation, not a tooling failure: the bypass mutant never reads the synchroniser's output at all, so a fault model based on extra settling cycles on a synchroniser's *registered output* has no path into the comparison it is meant to protect. Hunting for a friendlier mutant was deliberately not attempted.

**Bottom line: the injector is convergent and regression-safe, but has not yet demonstrated in-design value.** That is the honest state of it.

## Also noted

The CDC baseline recorded in `CLAUDE.md` is stale: documented `OK1 17791 / CDC 39 / OKX 330 / BAD 16088` vs. a fresh measurement of `18365 / 41 / 330 / 16126`. Not re-run in this PR; recorded so the discrepancy is not mistaken for a regression later.

## Files

- `rtl/soc/cdc/cdc_2ff_sync.sv` — randomised settling-delay injection, default off
- `tb/cocotb/soc/Makefile` — plumb `RAND_CDC_DELAY_EN`

The mutant used for the experiment was reverted and confirmed absent before committing.

## Test plan

- [x] Standalone harness: 0/2010 OFF vs 304/2010 ON
- [x] `soc_all` with injector OFF: 183/183, exit 0
- [x] In-design mutant: negative result, structurally explained
- [x] Mutant reverted; working tree clean
- [ ] Find a mutant inside the injector's actual fault model — one that reads a synchroniser's registered output — to demonstrate in-design value

## Bead

`rvs` **stays open** until the feature demonstrates in-design value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
