### PR TITLE
[Test] apb_cdc_bridge: widen post-reset recovery margin to STAGES+2 (bead 0eh)

### DIFF
--- a/tb/cocotb/soc/test_apb_cdc_bridge.py
+++ b/tb/cocotb/soc/test_apb_cdc_bridge.py
@@ -63,6 +63,34 @@ from cocotb.utils import get_sim_time
 # ---------------------------------------------------------------------------
 RESET_HOLD_NS = 300  # generous vs. SYNC_STAGES(2)+1 periods of any clock used here (max period 18 ns)
 
+
+def _post_reset_recovery_cycles(dut) -> int:
+    """Cycles to wait, on the relevant destination clock(s), after a reset
+    domain releases before code may assume this crossing's reset-status
+    synchronisers have resolved and issue a transaction expected to
+    succeed.
+
+    Both directions here are cdc_2ff_sync instances (SYNC_STAGES_TO_S /
+    SYNC_STAGES_TO_M, read back from the RTL via sync_stages_to_{s,m}_o
+    rather than hardcoded a second time -- see tb_apb_cdc_bridge.sv
+    header) whose NOMINAL settling latency is STAGES cycles. Under the
+    RAND_CDC_DELAY_EN settling-delay injector (bead
+    claude_verilog_test-rvs; default OFF, not shipped), either
+    synchroniser can legitimately take one extra cycle. A recovery wait
+    pinned to the bare nominal STAGES is exactly-tight against the
+    synchroniser's own worst case, not generously tight against it --
+    that is precisely what bead claude_verilog_test-0eh found: a literal
+    `ClockCycles(dut.m_clk, 3)` (== STAGES+1) in
+    test_availability_never_forwarded failed deterministically once the
+    injector's one-extra-cycle fault model was active, because the
+    post-recovery write landed one cycle before the synchroniser had
+    actually resolved. Returns STAGES+1 (worst-case settling) + 1 cycle of
+    slack for the receiving FSM to act on the newly-resolved value.
+    """
+    stages = max(int(dut.sync_stages_to_s_o.value), int(dut.sync_stages_to_m_o.value))
+    return stages + 2
+
+
 # ---------------------------------------------------------------------------
 # Module-level task handle list (guard against cross-test coroutine leakage,
 # same pattern as test_pmu.py's / test_async_axi_fifo.py's
@@ -268,8 +296,13 @@ async def _setup(dut, s_ns, m_ns, wait_states=0, err_addrs=None, mem=None) -> Si
     await Timer(RESET_HOLD_NS, units="ns")
     dut.s_rst_n.value = 1
     dut.m_rst_n.value = 1
-    await ClockCycles(dut.s_clk, 3)
-    await ClockCycles(dut.m_clk, 3)
+    # Post-reset recovery margin (bead claude_verilog_test-0eh) -- every
+    # test builds on this baseline wait before issuing its first
+    # transaction, so it must cover the synchronisers' worst case, not
+    # just their nominal latency.
+    n = _post_reset_recovery_cycles(dut)
+    await ClockCycles(dut.s_clk, n)
+    await ClockCycles(dut.m_clk, n)
 
     return SimpleNamespace(
         s_master=s_master,
@@ -537,8 +570,13 @@ async def _reset_mid_transaction_s_side_body(dut):
     _idle_s_side(dut)
     await ClockCycles(dut.s_clk, 5)
     dut.s_rst_n.value = 1
-    await ClockCycles(dut.s_clk, 3)
-    await ClockCycles(dut.m_clk, 3)
+    # Post-reset recovery margin (bead claude_verilog_test-0eh) -- the
+    # post-recovery write below assumes success, so this must cover the
+    # reset-status synchronisers' worst case, not just their nominal
+    # latency.
+    n = _post_reset_recovery_cycles(dut)
+    await ClockCycles(dut.s_clk, n)
+    await ClockCycles(dut.m_clk, n)
 
     await ClockCycles(dut.s_clk, 2)
     assert int(dut.s_pready.value) == 0, "s_pready must be idle-low after s-side reset recovery"
@@ -627,8 +665,13 @@ async def _reset_mid_transaction_m_side_body(dut):
 
     await ClockCycles(dut.m_clk, 5)
     dut.m_rst_n.value = 1
-    await ClockCycles(dut.s_clk, 3)
-    await ClockCycles(dut.m_clk, 3)
+    # Post-reset recovery margin (bead claude_verilog_test-0eh) -- the
+    # post-recovery write further below assumes success, so this must
+    # cover the reset-status synchronisers' worst case, not just their
+    # nominal latency.
+    n = _post_reset_recovery_cycles(dut)
+    await ClockCycles(dut.s_clk, n)
+    await ClockCycles(dut.m_clk, n)
 
     await ClockCycles(dut.s_clk, 2)
     assert int(dut.s_pready.value) == 0, "s_pready must return to idle-low after the error-completion pulse"
@@ -868,7 +911,18 @@ async def _availability_never_forwarded_body(dut):
 
     # Recover and confirm clean transactions afterward.
     dut.m_rst_n.value = 1
-    await ClockCycles(dut.m_clk, 3)
+    # Post-reset recovery margin (bead claude_verilog_test-0eh) -- THIS is
+    # the site the bead was filed against: the old bare `ClockCycles(dut.
+    # m_clk, 3)` (== SYNC_STAGES+1) was exactly-tight against the
+    # m_rst_n_i-status synchroniser into the s domain's own nominal
+    # latency, not generously tight against its worst case, so it failed
+    # deterministically once the settling-delay injector's one-extra-cycle
+    # fault model was active on that synchroniser. Also wait s_clk cycles
+    # (not just m_clk) since the post-recovery write below is issued from
+    # the s domain and is gated by the synchroniser that resolves there.
+    n = _post_reset_recovery_cycles(dut)
+    await ClockCycles(dut.s_clk, n)
+    await ClockCycles(dut.m_clk, n)
     # Re-check (now that m_rst_n_i has actually released, not just during
     # the never-forwarded completion itself) that nothing spurious reached
     # the destination -- same no-stale-level-collision property as
@@ -1041,8 +1095,13 @@ async def _availability_back_to_back_resets_workload(dut, s_ns, m_ns):
     dut.m_rst_n.value = 0
     await ClockCycles(dut.m_clk, 5)
     dut.m_rst_n.value = 1
-    await ClockCycles(dut.m_clk, 3)
-    await ClockCycles(dut.s_clk, 3)
+    # Post-reset recovery margin (bead claude_verilog_test-0eh) -- the
+    # write below assumes success, so this must cover the reset-status
+    # synchronisers' worst case, not just their nominal latency. Applies
+    # to both pulses below.
+    n = _post_reset_recovery_cycles(dut)
+    await ClockCycles(dut.m_clk, n)
+    await ClockCycles(dut.s_clk, n)
 
     # Between the two pulses, the destination is genuinely alive -- this
     # must complete for real.
@@ -1054,8 +1113,8 @@ async def _availability_back_to_back_resets_workload(dut, s_ns, m_ns):
     dut.m_rst_n.value = 0
     await ClockCycles(dut.m_clk, 5)
     dut.m_rst_n.value = 1
-    await ClockCycles(dut.m_clk, 3)
-    await ClockCycles(dut.s_clk, 3)
+    await ClockCycles(dut.m_clk, n)
+    await ClockCycles(dut.s_clk, n)
 
     completed_before = ctx.responder.completed
     data, ok2 = await ctx.s_master.read(addr)
@@ -1307,8 +1366,13 @@ async def _apb_reset_asym_s_held_m_free_body(dut, s_ns, m_ns) -> None:
     await RisingEdge(dut.m_clk)
 
     dut.s_rst_n.value = 1
-    await ClockCycles(dut.s_clk, 3)
-    await ClockCycles(dut.m_clk, 3)
+    # Post-reset recovery margin (bead claude_verilog_test-0eh) -- the
+    # post-recovery write below assumes success, so this must cover the
+    # reset-status synchronisers' worst case, not just their nominal
+    # latency.
+    n = _post_reset_recovery_cycles(dut)
+    await ClockCycles(dut.s_clk, n)
+    await ClockCycles(dut.m_clk, n)
 
     s_master = APB4Master(dut, "s_", dut.s_clk)
     ok = await s_master.write(0x900, 0xDEADBEEF)
@@ -1412,8 +1476,13 @@ async def _apb_reset_asym_staggered_body(dut, s_ns, m_ns, order) -> None:
             await RisingEdge(dut.s_clk)  # land back in a writable phase before the release write below
 
         getattr(dut, f"{second}_rst_n").value = 1
-        await ClockCycles(dut.s_clk, 3)
-        await ClockCycles(dut.m_clk, 3)
+        # Post-reset recovery margin (bead claude_verilog_test-0eh) -- the
+        # post-recovery write below assumes success, so this must cover
+        # the reset-status synchronisers' worst case, not just their
+        # nominal latency.
+        n = _post_reset_recovery_cycles(dut)
+        await ClockCycles(dut.s_clk, n)
+        await ClockCycles(dut.m_clk, n)
 
         s_master2 = APB4Master(dut, "s_", dut.s_clk)
         ok = await s_master2.write(0xB00 + idx, 0x10000000 + idx)


### PR DESCRIPTION
## Summary

Bead `claude_verilog_test-0eh`: `test_apb_cdc_bridge.py::test_availability_never_forwarded` fails deterministically at `assert ok2, "post-recovery write reported pslverr"` (was line 881) once `rtl/soc/cdc/cdc_2ff_sync.sv`'s `RAND_CDC_DELAY_EN` settling-delay injector (bead `rvs`, default OFF) is forced ON at every instance. This is **not an RTL defect** — the design's data correctness is intact. It is a test-authored recovery margin (`ClockCycles(dut.m_clk, 3)`) that is exactly-tight against the `m_rst_n_i`-status synchroniser's (`cdc_2ff_sync`, `STAGES=2`) own *nominal* 2-cycle latency, not generously tight against its *worst case* (`STAGES+1` under the injector's one-extra-cycle fault model).

## Fix

Added `_post_reset_recovery_cycles(dut)` to `tb/cocotb/soc/test_apb_cdc_bridge.py`, deriving `STAGES + 2` (worst-case settling + 1 cycle of slack) from the DUT's own `sync_stages_to_s_o` / `sync_stages_to_m_o` outputs — following the pattern the file already established elsewhere (`test_availability_never_forwarded`'s own precondition wait) — rather than hardcoding a duplicate literal that could silently drift from the RTL.

## Sibling-site audit (bead's 9 listed lines + a fuller grep)

A wider grep for `ClockCycles(dut.{s,m}_clk, 3)` found **16** occurrences, not the 10 the bead enumerated (9 sibling lines + the bug site). I judged and handled all of them:

**Fixed (share the reset-release-to-usable assumption — a post-recovery transaction is issued and assumed to succeed immediately after):**
- `_setup()` helper (bead lines 271-272) — the shared baseline every test builds on
- `test_reset_mid_transaction_s_side` (bead lines 540-541)
- `test_reset_mid_transaction_m_side` (bead lines 630-631)
- `test_availability_never_forwarded` (line ~871) — the bug site itself; also switched to waiting `s_clk` (not just `m_clk`), since the post-recovery write is issued from, and gated by, the synchroniser resolving in the `s` domain
- `test_availability_back_to_back_resets_*` (bead lines 1044-1045), **both** pulses (the second pulse's identical pattern, ~10 lines later, wasn't in the bead's list but shares the exact same bug)
- `test_reset_asym_s_held_m_free` (not in the bead's list; same pattern)
- `test_reset_asym_staggered_*` (not in the bead's list; same pattern, inside a parametrized loop)

**Left unchanged:**
- Line 593 (bead-listed) — `await ClockCycles(dut.m_clk, 3)  # let the request cross into the m domain and be forwarded first`. This is a request-propagation wait, not a reset-recovery margin; its own comment says so, and bumping it would not be addressing the same defect class. Per the task instructions, not blanket-bumped.

## Firmware/integration audit (bead's open question)

Checked whether any *real* firmware or integration RTL assumes a similarly tight N-cycle reset-release-to-usable contract across this same crossing:

- `sw/`: no references to the PMU, `APB_PLL2`, or `apb_cdc_bridge` at all — no firmware exercises this crossing yet (consistent with the existing note in CLAUDE.md that PMU-driven cross-domain power-cycling is untested, bead `2k8`).
- `rtl/soc/soc_top.sv` (PMU reset-release / clock-ungate path, `pmu_cpu_rst_n_cpu_sync`, `cpu_gated_clk_en`): reactive, not cycle-counted — `cpu_gated_clk_en = ~pmu_cpu_clk_dis_sync & pmu_cpu_rst_n_cpu_sync` gates directly on the synchronised signal values, and `pmu.sv`'s sequencer FSM walks one action per cycle keyed off the live synchronised state, not a fixed wait count.
- `rtl/soc/apb_cdc_bridge.sv` itself: the protocol is fully handshake/level-driven (`s_state_q`/`d_state_q` wait on `ack_s`/`req_m`/`m_rst_n_s` directly), never a fixed cycle counter internally.

**Answer: no** — this tight-margin assumption is confined to the testbench; no real firmware or RTL integration path shares it. No new bead filed.

## Verification (both real runs, `.claude/worktrees/apb-cdc-fix` isolated worktree)

- **Injector OFF (default)**: `nix develop --command make -C tb/cocotb/soc apb_cdc_bridge` → `TESTS=23 PASS=23 FAIL=0 SKIP=0`
- **Injector ON** (`RAND_CDC_DELAY_EN` default flipped to `1'b1` in `cdc_2ff_sync.sv` for the run only, then reverted — not part of this diff): same command → `TESTS=23 PASS=23 FAIL=0 SKIP=0`, including `test_availability_never_forwarded` and both `test_availability_back_to_back_resets_*` tests, which previously reproduced the bead's deterministic failure.

## Test plan
- [x] `apb_cdc_bridge` suite, injector OFF: 23/23 PASS
- [x] `apb_cdc_bridge` suite, injector forced ON at every `cdc_2ff_sync` instance: 23/23 PASS (previously-deterministic failure gone)
- [x] `python3 -m py_compile` on the modified test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)