### PR TITLE
[Fix] eda-mcp get_area: retract the false utl::Logger root cause (bead pzj)

### DIFF
--- a/tools/eda/README.md
+++ b/tools/eda/README.md
@@ -118,13 +118,21 @@ under `sim/build/eda-logs/` (override with `EDA_LOG_DIR`). `run_tcl`/`get_area`/
 `get_power`/`check_setup` inline up to 4000 chars of text with an explicit
 `truncated` flag; the full text is always on disk.
 
-**Known OpenROAD limitation:** `report_design_area`/`report_cell_usage` print
-through OpenROAD's own `utl::Logger`, not the STA report-string channel that
-`sta::redirect_file_begin` hooks (confirmed on OpenROAD 26Q2 by comparing
-against `report_power`, which *does* go through that channel and captures
-correctly). The session driver cannot capture their text, so `get_area` reports
-`status: ERROR` rather than a false `PASS` with a silently empty report — same
-rule as the empty-report case below.
+**`get_area` needs an ODB, not just a linked netlist.** Load the design with
+`load_odb` (`read_db`) before calling it. After `load_design`
+(`read_liberty` + `read_verilog` + `link_design`) there is an STA network but
+no ODB block for `report_design_area` to measure, and the reply is
+`status: ERROR` with an empty report rather than a false `PASS` — same rule as
+the empty-report case below.
+
+> **Retraction (bead `pzj`, 2026-08-15).** This section previously claimed
+> `report_design_area`/`report_cell_usage` print through `utl::Logger`, bypass
+> `sta::redirect_file_begin`, and are therefore uncapturable by this driver.
+> **That is wrong.** Measured on OpenROAD 26Q2 against run 23's final ODB
+> (`RUN_2026-08-09_14-36-16/final/odb/soc_top.odb`), the combined command
+> `report_design_area; report_cell_usage` is captured in full — 497 characters,
+> both the design-area line and the complete cell-type table. `utl::report` is
+> captured too. No `run_tcl`/`exec` workaround is needed.
 
 ### Setup
 

--- a/tools/eda/mcp/session_server.py
+++ b/tools/eda/mcp/session_server.py
@@ -280,24 +280,33 @@ class EdaSessionServer:
         out, err = self._run("report_design_area; report_cell_usage")
         report = self._save("area", out)
         if not err and not out.strip():
-            # report_design_area/report_cell_usage print through OpenROAD's
-            # own Logger (utl::report), not the STA report-string channel
-            # that sta::redirect_file_begin hooks -- confirmed on OpenROAD
-            # 26Q2 by comparing against report_power (which does go through
-            # that channel and captures fine). The text still lands on the
-            # session's real stdout/terminal, it just never reaches `out`.
-            # An empty report here does not mean a clean run; refuse to call
-            # it PASS (same rule summarize.py enforces for opensta -- bead
-            # dwp).
+            # Guard, not a known defect. Both commands DO route through
+            # sta::redirect_file_begin and capture correctly -- measured on
+            # OpenROAD 26Q2 against run 23's final ODB: the combined command
+            # returns 497 chars ("Design area 235977 um^2 94% utilization."
+            # plus the full cell-type table). An earlier note here claimed
+            # they bypass the redirect via utl::Logger and are uncapturable;
+            # that was wrong and is retracted (bead pzj).
+            #
+            # The realistic way to land here is a session with no ODB block:
+            # get_area needs a design loaded by load_odb (read_db). After
+            # load_design (read_liberty + read_verilog + link_design) there
+            # is an STA network but no block for report_design_area to
+            # measure. With nothing loaded at all, OpenROAD raises a real Tcl
+            # error ("no network has been linked") and `err` is set instead.
+            #
+            # Silence is still never PASS -- same rule summarize.py enforces
+            # for opensta (bead dwp).
             return {
                 "status": "ERROR",
                 "error": (
                     "report_design_area/report_cell_usage produced no "
-                    "captured output. These OpenROAD commands write via "
-                    "utl::Logger and bypass sta::redirect_file_begin, so "
-                    "this session driver cannot capture them -- use run_tcl "
-                    "with a script that redirects via 'exec' or read the "
-                    ".odb report_design_area output directly."
+                    "captured output and raised no Tcl error. Most likely "
+                    "this session has no ODB block: use load_odb (read_db), "
+                    "not load_design, before get_area. If an ODB is loaded, "
+                    "this is an unknown condition -- inspect the saved "
+                    "report path rather than treating the empty result as a "
+                    "clean design."
                 ),
                 "report": report,
                 "text": _truncate(out),


### PR DESCRIPTION
Closes bead `claude_verilog_test-pzj` — but **not** the way the bead expected.

## The bead was wrong, and this retracts it

`pzj` recorded that OpenROAD's `report_design_area`/`report_cell_usage` print via `utl::Logger`, bypass the `sta::redirect_file_begin` channel `tcl_session` captures, and are therefore uncapturable by this driver. `get_area` returned `status: ERROR` by design, and `tools/eda/README.md` documented it as a permanent **"Known OpenROAD limitation"**.

That root cause does not hold.

## Measurement

On OpenROAD 26Q2, against run 23's final ODB (`/nobackup/asap7_soc_runs/RUN_2026-08-09_14-36-16/final/odb/soc_top.odb`), the verbatim command `get_area` issues — `report_design_area; report_cell_usage` — is captured **in full** through the existing redirect:

```
Design area 235977 um^2 94% utilization.
Cell type report:                       Count       Area
  Macro                                     2  132500.00
  Endcap cell                           22596     658.90
  Fill cell                                 2       0.09
  Antenna cell                         427404   69040.31
  Tie cell                                677      29.61
  Standard cell                        244229   33747.68
  Total                                694910  235976.59
```

497 characters, both commands, nothing missing. A separate probe confirms plain `utl::report` is captured too — so the `utl::Logger` premise fails at its root, not just for these two commands.

## What actually causes an empty capture

A session with **no ODB block**. `get_area` needs a design loaded via `load_odb` (`read_db`). After `load_design` (`read_liberty` + `read_verilog` + `link_design`) there is an STA network but no block for `report_design_area` to measure. With nothing loaded at all, OpenROAD raises a genuine Tcl error (`no network has been linked`), so `err` is set — that path was never the silent one.

## Changes — diagnosis only, no behavioural weakening

- **The zero-output guard stays.** Silence is still never `PASS` (bead `dwp` rule).
- The error message now points at the real cause (use `load_odb`, not `load_design`) instead of sending callers to an unnecessary `run_tcl`/`exec` workaround.
- README's "Known OpenROAD limitation" section is replaced by the actual precondition, with an **explicit dated retraction** so the old claim is not silently rewritten out of the record.

## Verification

With the patched server:

| case | result |
| :--- | :--- |
| real ODB via `load_odb` | `get_area` → `status: PASS`, full non-empty report |
| no design loaded | `SessionError`, converted to an `ERROR` reply by the dispatcher (`session_server.py:375`) — no crash, no false PASS |

## Note

No new false-PASS risk is introduced: the only status change is `ERROR → PASS` in the case where a real, non-empty report is now demonstrably produced.